### PR TITLE
nad-fn

### DIFF
--- a/krm-functions/nad-fn/go.mod
+++ b/krm-functions/nad-fn/go.mod
@@ -1,0 +1,3 @@
+module github.com/nephio-project/nephio/krm-functions/nad-fn
+
+go 1.20


### PR DESCRIPTION
nad fn is part of Nephio R1. If operates on VLAN/IP Allocation and performs CRUD operations on a NAD CRD