### PR TITLE
adds support for unit tests, golangci-lint and gosec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,28 @@
+run:
+  skip-dirs:
+    - vendor
+
+  skip-files:
+    - ".*\\_test.go$"
+
+linters:
+  # refer https://golangci-lint.run/usage/linters/
+  disable-all: true
+  enable:
+    # errcheck is a program for checking for unchecked errors in Go code. These unchecked errors can be critical bugs in some cases
+    - errcheck
+    # checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
+    - gofmt
+    # Linter for Go source code that specializes in simplifying code
+    - gosimple
+    # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - govet
+    # Detects when assignments to existing variables are not used
+    - ineffassign
+    # Checks for misuse of Sprintf to construct a host with port in a URL.
+    - nosprintfhostport
+    - staticcheck
+    # Like the front-end of a Go compiler, parses and type-checks Go code
+    - typecheck
+    # Checks Go code for unused constants, variables, functions and types
+    - unused

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -8,27 +8,17 @@ presubmits:
         command:
         - make
         args:
-        - test
-  - name: presubmit-nephio-go-fmt
+        - unit
+  - name: presubmit-nephio-gosec
     decorate: true
     run_if_changed: "(\\.go)$"
     spec:
       containers:
-      - image: golang:1.20.2
+      - image: securego/gosec:2.15.0
         command:
         - make
         args:
-        - fmt
-  - name: presubmit-nephio-go-vet
-    decorate: true
-    run_if_changed: "(\\.go)$"
-    spec:
-      containers:
-      - image: golang:1.20.2
-        command:
-        - make
-        args:
-        - vet
+        - gosec
   - name: presubmit-nephio-golangci-lint
     decorate: true
     run_if_changed: "(\\.go)$"

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,53 @@
-.PHONY: fmt
-fmt: ## Run go fmt against code.
-	go fmt ./...
+GO_VERSION ?= 1.20.2
+GOLANG_CI_VER ?= v1.52
+GOSEC_VER ?= 2.15.0
+TEST_COVERAGE_FILE=lcov.info
+TEST_COVERAGE_HTML_FILE=coverage_unit.html
+TEST_COVERAGE_FUNC_FILE=func_coverage.out
 
-.PHONY: vet
-vet: ## Run go vet against code.
-	go vet ./...
+# CONTAINER_RUNNABLE checks if tests and lint check can be run inside container.
+PODMAN ?= $(shell podman -v > /dev/null 2>&1; echo $$?)
+ifeq ($(PODMAN), 0)
+CONTAINER_RUNTIME=podman
+else
+CONTAINER_RUNTIME=docker
+endif
+CONTAINER_RUNNABLE ?= $(shell $(CONTAINER_RUNTIME) -v > /dev/null 2>&1; echo $$?)
 
-.PHONY: test
-test: fmt vet ## Run tests.
-	go test ./... -coverprofile cover.out
+.PHONY: unit_clean
+unit_clean: ## clean up the unit test artifacts created
+ifeq ($(CONTAINER_RUNNABLE), 0)
+		$(CONTAINER_RUNTIME) system prune -f
+endif
+		rm ${TEST_COVERAGE_FILE} ${TEST_COVERAGE_HTML_FILE} ${TEST_COVERAGE_FUNC_FILE} > /dev/null 2>&1
+
+.PHONY: unit
+unit: ## Run unit tests against code.
+ifeq ($(CONTAINER_RUNNABLE), 0)
+		$(CONTAINER_RUNTIME) run -it -v ${PWD}:/go/src -w /go/src docker.io/library/golang:${GO_VERSION}-alpine3.17 \
+         /bin/sh -c "go test ./... -v -coverprofile ${TEST_COVERAGE_FILE}; \
+         go tool cover -html=${TEST_COVERAGE_FILE} -o ${TEST_COVERAGE_HTML_FILE}; \
+         go tool cover -func=${TEST_COVERAGE_FILE} -o ${TEST_COVERAGE_FUNC_FILE}"
+else
+		go test ./... -v -coverprofile ${TEST_COVERAGE_FILE}
+		go tool cover -html=${TEST_COVERAGE_FILE} -o ${TEST_COVERAGE_HTML_FILE}
+		go tool cover -func=${TEST_COVERAGE_FILE} -o ${TEST_COVERAGE_FUNC_FILE}
+endif
+
+# Install link at https://golangci-lint.run/usage/install/ if not running inside a container
+.PHONY: lint
+lint: ## Run lint  against code.
+ifeq ($(CONTAINER_RUNNABLE), 0)
+		$(CONTAINER_RUNTIME) run -it -v ${PWD}:/go/src -w /go/src docker.io/golangci/golangci-lint:${GOLANG_CI_VER}-alpine golangci-lint run ./... -v
+else
+		golangci-lint run ./... -v
+endif
+
+# Install link at https://github.com/securego/gosec#install if not running inside a container
+.PHONY: gosec
+gosec: ## inspects source code for security problem by scanning the Go Abstract Syntax Tree
+ifeq ($(CONTAINER_RUNNABLE), 0)
+		$(CONTAINER_RUNTIME) run -it -v ${PWD}:/go/src -w /go/src docker.io/securego/gosec:${GOSEC_VER} ./...
+else
+		gosec ./...
+endif


### PR DESCRIPTION
- adds support for running unit tests inside of containers, generates html output file to visualize code coverage by tests
- adds support for running golangci-lint inside of containers (https://golangci-lint.run/)
- adds support for running gosec inside of containers (https://github.com/securego/gosec)
