### PR TITLE
Add type-safety to KubeObjectExt in a non-backward compatible manner

### DIFF
--- a/krm-functions/lib/interface/v1alpha1/interface.go
+++ b/krm-functions/lib/interface/v1alpha1/interface.go
@@ -17,19 +17,21 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	"github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
 	nephioreqv1alpha1 "github.com/nephio-project/api/nf_requirements/v1alpha1"
 	"github.com/nephio-project/nephio/krm-functions/lib/kubeobject"
 )
 
 type Interface struct {
-	kubeobject.KubeObjectExt[*nephioreqv1alpha1.Interface]
+	kubeobject.KubeObjectExt[nephioreqv1alpha1.Interface]
 }
 
 // NewFromKubeObject creates a new parser interface
 // It expects a *fn.KubeObject as input representing the serialized yaml file
 func NewFromKubeObject(o *fn.KubeObject) (*Interface, error) {
-	r, err := kubeobject.NewFromKubeObject[*nephioreqv1alpha1.Interface](o)
+	r, err := kubeobject.NewFromKubeObject[nephioreqv1alpha1.Interface](o)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +41,7 @@ func NewFromKubeObject(o *fn.KubeObject) (*Interface, error) {
 // NewFromYAML creates a new parser interface
 // It expects a raw byte slice as input representing the serialized yaml file
 func NewFromYAML(b []byte) (*Interface, error) {
-	r, err := kubeobject.NewFromYaml[*nephioreqv1alpha1.Interface](b)
+	r, err := kubeobject.NewFromYaml[nephioreqv1alpha1.Interface](b)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +51,10 @@ func NewFromYAML(b []byte) (*Interface, error) {
 // NewFromGoStruct creates a new parser interface
 // It expects a go struct representing the interface krm resource
 func NewFromGoStruct(x *nephioreqv1alpha1.Interface) (*Interface, error) {
-	r, err := kubeobject.NewFromGoStruct[*nephioreqv1alpha1.Interface](x)
+	if x == nil {
+		return nil, fmt.Errorf("cannot initialize with nil pointer")
+	}
+	r, err := kubeobject.NewFromGoStruct(*x)
 	if err != nil {
 		return nil, err
 	}
@@ -57,9 +62,9 @@ func NewFromGoStruct(x *nephioreqv1alpha1.Interface) (*Interface, error) {
 }
 
 func (r *Interface) SetSpec(spec nephioreqv1alpha1.InterfaceSpec) error {
-	return r.KubeObjectExt.SetSpec(spec)
+	return r.KubeObjectExt.UnsafeSetSpec(spec)
 }
 
 func (r *Interface) SetStatus(spec nephioreqv1alpha1.InterfaceStatus) error {
-	return r.KubeObjectExt.SetStatus(spec)
+	return r.KubeObjectExt.UnsafeSetStatus(spec)
 }

--- a/krm-functions/lib/interface/v1alpha1/interface.go
+++ b/krm-functions/lib/interface/v1alpha1/interface.go
@@ -17,8 +17,6 @@
 package v1alpha1
 
 import (
-	"fmt"
-
 	"github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
 	nephioreqv1alpha1 "github.com/nephio-project/api/nf_requirements/v1alpha1"
 	"github.com/nephio-project/nephio/krm-functions/lib/kubeobject"
@@ -51,10 +49,7 @@ func NewFromYAML(b []byte) (*Interface, error) {
 // NewFromGoStruct creates a new parser interface
 // It expects a go struct representing the interface krm resource
 func NewFromGoStruct(x *nephioreqv1alpha1.Interface) (*Interface, error) {
-	if x == nil {
-		return nil, fmt.Errorf("cannot initialize with nil pointer")
-	}
-	r, err := kubeobject.NewFromGoStruct(*x)
+	r, err := kubeobject.NewFromGoStruct(x)
 	if err != nil {
 		return nil, err
 	}

--- a/krm-functions/lib/interface/v1alpha1/interface_test.go
+++ b/krm-functions/lib/interface/v1alpha1/interface_test.go
@@ -106,7 +106,7 @@ func TestNewFromGoStruct(t *testing.T) {
 		},
 		"TestNewFromGoStructNil": {
 			input:       nil,
-			errExpected: false, // new approach does not return an error
+			errExpected: true,
 		},
 	}
 

--- a/krm-functions/lib/ipalloc/v1alpha1/ipalloc.go
+++ b/krm-functions/lib/ipalloc/v1alpha1/ipalloc.go
@@ -17,19 +17,21 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	"github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
 	"github.com/nephio-project/nephio/krm-functions/lib/kubeobject"
 	ipamv1alpha1 "github.com/nokia/k8s-ipam/apis/alloc/ipam/v1alpha1"
 )
 
 type IPAllocation struct {
-	kubeobject.KubeObjectExt[*ipamv1alpha1.IPAllocation]
+	kubeobject.KubeObjectExt[ipamv1alpha1.IPAllocation]
 }
 
 // NewFromKubeObject creates a new KubeObjectExt
 // It expects a *fn.KubeObject as input representing the serialized yaml file
 func NewFromKubeObject(o *fn.KubeObject) (*IPAllocation, error) {
-	r, err := kubeobject.NewFromKubeObject[*ipamv1alpha1.IPAllocation](o)
+	r, err := kubeobject.NewFromKubeObject[ipamv1alpha1.IPAllocation](o)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +41,7 @@ func NewFromKubeObject(o *fn.KubeObject) (*IPAllocation, error) {
 // NewFromYAML creates a new KubeObjectExt
 // It expects a raw byte slice as input representing the serialized yaml file
 func NewFromYAML(b []byte) (*IPAllocation, error) {
-	r, err := kubeobject.NewFromYaml[*ipamv1alpha1.IPAllocation](b)
+	r, err := kubeobject.NewFromYaml[ipamv1alpha1.IPAllocation](b)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +51,10 @@ func NewFromYAML(b []byte) (*IPAllocation, error) {
 // NewFromGoStruct creates a new KubeObjectExt
 // It expects a go struct representing the KRM resource
 func NewFromGoStruct(x *ipamv1alpha1.IPAllocation) (*IPAllocation, error) {
-	r, err := kubeobject.NewFromGoStruct[*ipamv1alpha1.IPAllocation](x)
+	if x == nil {
+		return nil, fmt.Errorf("cannot initialize with nil pointer")
+	}
+	r, err := kubeobject.NewFromGoStruct(*x)
 	if err != nil {
 		return nil, err
 	}
@@ -57,9 +62,9 @@ func NewFromGoStruct(x *ipamv1alpha1.IPAllocation) (*IPAllocation, error) {
 }
 
 func (r *IPAllocation) SetSpec(spec ipamv1alpha1.IPAllocationSpec) error {
-	return r.KubeObjectExt.SetSpec(spec)
+	return r.KubeObjectExt.UnsafeSetSpec(spec)
 }
 
 func (r *IPAllocation) SetStatus(spec ipamv1alpha1.IPAllocationStatus) error {
-	return r.KubeObjectExt.SetStatus(spec)
+	return r.KubeObjectExt.UnsafeSetStatus(spec)
 }

--- a/krm-functions/lib/ipalloc/v1alpha1/ipalloc.go
+++ b/krm-functions/lib/ipalloc/v1alpha1/ipalloc.go
@@ -17,8 +17,6 @@
 package v1alpha1
 
 import (
-	"fmt"
-
 	"github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
 	"github.com/nephio-project/nephio/krm-functions/lib/kubeobject"
 	ipamv1alpha1 "github.com/nokia/k8s-ipam/apis/alloc/ipam/v1alpha1"
@@ -51,10 +49,7 @@ func NewFromYAML(b []byte) (*IPAllocation, error) {
 // NewFromGoStruct creates a new KubeObjectExt
 // It expects a go struct representing the KRM resource
 func NewFromGoStruct(x *ipamv1alpha1.IPAllocation) (*IPAllocation, error) {
-	if x == nil {
-		return nil, fmt.Errorf("cannot initialize with nil pointer")
-	}
-	r, err := kubeobject.NewFromGoStruct(*x)
+	r, err := kubeobject.NewFromGoStruct(x)
 	if err != nil {
 		return nil, err
 	}

--- a/krm-functions/lib/ipalloc/v1alpha1/ipalloc_test.go
+++ b/krm-functions/lib/ipalloc/v1alpha1/ipalloc_test.go
@@ -109,7 +109,7 @@ func TestNewFromGoStruct(t *testing.T) {
 		},
 		"Nil": {
 			input:       nil,
-			errExpected: false, // new approach does not return an error
+			errExpected: true,
 		},
 	}
 

--- a/krm-functions/lib/kubeobject/kubeobject.go
+++ b/krm-functions/lib/kubeobject/kubeobject.go
@@ -31,6 +31,7 @@ type KubeObjectExt[T1 any] struct {
 }
 
 func (r *KubeObjectExt[T1]) GetGoStruct() (T1, error) {
+	validateTypeOrPanic[T1]()
 	var x T1
 	err := r.KubeObject.As(&x)
 	return x, err
@@ -39,6 +40,7 @@ func (r *KubeObjectExt[T1]) GetGoStruct() (T1, error) {
 // NewFromKubeObject returns a KubeObjectExt struct
 // It expects a fn.KubeObject as input representing the serialized yaml file
 func NewFromKubeObject[T1 any](o *fn.KubeObject) (*KubeObjectExt[T1], error) {
+	validateTypeOrPanic[T1]()
 	if o == nil {
 		return nil, fmt.Errorf("cannot initialize with a nil object")
 	}
@@ -48,6 +50,7 @@ func NewFromKubeObject[T1 any](o *fn.KubeObject) (*KubeObjectExt[T1], error) {
 // NewFromYaml returns a KubeObjectExt struct
 // It expects raw byte slice as input representing the serialized yaml file
 func NewFromYaml[T1 any](b []byte) (*KubeObjectExt[T1], error) {
+	validateTypeOrPanic[T1]()
 	o, err := fn.ParseKubeObject(b)
 	if err != nil {
 		return nil, err
@@ -58,6 +61,7 @@ func NewFromYaml[T1 any](b []byte) (*KubeObjectExt[T1], error) {
 // NewFromGoStruct returns a KubeObjectExt struct
 // It expects a go struct representing the interface krm resource
 func NewFromGoStruct[T1 any](x T1) (*KubeObjectExt[T1], error) {
+	validateTypeOrPanic[T1]()
 	o, err := fn.NewFromTypedObject(x)
 	if err != nil {
 		return nil, err
@@ -65,38 +69,32 @@ func NewFromGoStruct[T1 any](x T1) (*KubeObjectExt[T1], error) {
 	return NewFromKubeObject[T1](o)
 }
 
-// SetSpec sets the `spec` field of a KubeObjectExt to the value of `newSpec`,
+// UnsafeSetSpec sets the `spec` field of a KubeObjectExt to the value of `newSpec`,
 // while trying to keep as much formatting as possible
-func (o *KubeObjectExt[T1]) SetSpec(newSpec interface{}) error {
+func (o *KubeObjectExt[T1]) UnsafeSetSpec(newSpec interface{}) error {
 	return setNestedFieldKeepFormatting(&(o.KubeObject), newSpec, "spec")
 }
 
-// SetStatus sets the `status` field of a KubeObjectExt to the value of `newStatus`,
+// UnsafeSetStatus sets the `status` field of a KubeObjectExt to the value of `newStatus`,
 // while trying to keep as much formatting as possible
-func (o *KubeObjectExt[T1]) SetStatus(newStatus interface{}) error {
+func (o *KubeObjectExt[T1]) UnsafeSetStatus(newStatus interface{}) error {
 	return setNestedFieldKeepFormatting(&o.KubeObject, newStatus, "status")
 }
 
 // SetSpec sets the `spec` field of a KubeObjectExt to the value of `newSpec`,
 // while trying to keep as much formatting as possible
-func (o *KubeObjectExt[T1]) SafeSetSpec(value T1) error {
-	newSpec, err := o.getField(value, "Spec")
-	if err != nil {
-		// TODO: consider panicking here
-		return err
-	}
-	return setNestedFieldKeepFormatting(&(o.KubeObject), newSpec, "spec")
+func (o *KubeObjectExt[T1]) SetSpec(value T1) error {
+	return setNestedFieldKeepFormatting(&(o.KubeObject), o.getFieldOrPanic(value, "Spec"), "spec")
 }
 
 // SetStatus sets the `status` field of a KubeObjectExt to the value of `newStatus`,
 // while trying to keep as much formatting as possible
-func (o *KubeObjectExt[T1]) SafeSetStatus(value T1) error {
-	newStatus, err := o.getField(value, "Status")
-	if err != nil {
-		// TODO: consider panicking here
-		return err
-	}
-	return setNestedFieldKeepFormatting(&o.KubeObject, newStatus, "status")
+func (o *KubeObjectExt[T1]) SetStatus(value T1) error {
+	return setNestedFieldKeepFormatting(&o.KubeObject, o.getFieldOrPanic(value, "Status"), "status")
+}
+
+func (o *KubeObjectExt[T1]) SetNestedFieldKeepFormatting(value interface{}, fields ...string) error {
+	return setNestedFieldKeepFormatting(&o.KubeObject, value, fields...)
 }
 
 // setNestedFieldKeepFormatting is similar to KubeObject.SetNestedField(), but keeps the
@@ -120,19 +118,27 @@ func setNestedFieldKeepFormatting(obj *fn.KubeObject, value interface{}, fields 
 
 ///////////////// internals
 
-func (o *KubeObjectExt[T1]) getField(value T1, fieldName string) (interface{}, error) {
+func (o *KubeObjectExt[T1]) getFieldOrPanic(value T1, fieldName string) interface{} {
 	v := reflect.ValueOf(value)
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
 	}
 	if v.Kind() != reflect.Struct {
-		return nil, fmt.Errorf("type %q is not a struct, so it doesn't have a %q field", v.Type().Name(), fieldName)
+		panic(fmt.Sprintf("type %q is not a struct, so it doesn't have a %q field", v.Type().Name(), fieldName))
 	}
 	field := v.FieldByName(fieldName)
 	if !field.IsValid() {
-		return nil, fmt.Errorf("type %q doesn't have a %q field", v.Type().Name(), fieldName)
+		panic(fmt.Sprintf("type %q doesn't have a %q field", v.Type().Name(), fieldName))
 	}
-	return field.Interface(), nil
+	return field.Interface()
+}
+
+func validateTypeOrPanic[T1 any]() {
+	var x T1
+	v := reflect.TypeOf(x)
+	if v.Kind() != reflect.Struct {
+		panic(fmt.Sprintf("type %q is not a struct", v.Name()))
+	}
 }
 
 // shallowCopyComments copies comments from `src` to `dst` non-recursively

--- a/krm-functions/lib/kubeobject/kubeobject_test.go
+++ b/krm-functions/lib/kubeobject/kubeobject_test.go
@@ -326,7 +326,7 @@ func TestNewFromGoStruct(t *testing.T) {
 				},
 			},
 		}
-		deploymentKubeObject, _ := NewFromGoStruct(deploymentReceived)
+		deploymentKubeObject, _ := NewFromGoStruct(&deploymentReceived)
 
 		s, _, err := deploymentKubeObject.NestedString([]string{"metadata", "name"}...)
 		if err != nil {
@@ -489,7 +489,7 @@ func TestKubeObjectExtSetSpec(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 
-			tc.transform(&deploy)
+			tc.transform(deploy)
 
 			err = koe.SetSpec(deploy)
 			if err != nil {
@@ -526,7 +526,7 @@ func TestKubeObjectExtSetStatus(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 
-			tc.transform(&deploy)
+			tc.transform(deploy)
 
 			err = koe.SetStatus(deploy)
 			if err != nil {
@@ -545,7 +545,8 @@ func TestNewFromGoStructWithPointerType(t *testing.T) {
 		}
 	}()
 
-	_, _ = NewFromGoStruct(&appsv1.Deployment{})
+	deploy := &appsv1.Deployment{}
+	_, _ = NewFromGoStruct(&deploy)
 }
 
 func TestNewFromKubeObjectWithPointerType(t *testing.T) {
@@ -568,11 +569,11 @@ func TestSetSpecWithMissingSpecField(t *testing.T) {
 	type NoSpecOrStatus struct{}
 	var val NoSpecOrStatus
 
-	koe, err := NewFromGoStruct(val)
+	koe, err := NewFromGoStruct(&val)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	_ = koe.SetSpec(val)
+	_ = koe.SetSpec(&val)
 }
 
 func TestSetStatusWithMissingStatusField(t *testing.T) {
@@ -585,9 +586,9 @@ func TestSetStatusWithMissingStatusField(t *testing.T) {
 	type NoSpecOrStatus struct{}
 	var val NoSpecOrStatus
 
-	koe, err := NewFromGoStruct(val)
+	koe, err := NewFromGoStruct(&val)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	_ = koe.SetStatus(val)
+	_ = koe.SetStatus(&val)
 }

--- a/krm-functions/lib/kubeobject/kubeobject_test.go
+++ b/krm-functions/lib/kubeobject/kubeobject_test.go
@@ -491,34 +491,13 @@ func TestKubeObjectExtSetSpec(t *testing.T) {
 
 			tc.transform(&deploy)
 
-			err = koe.SafeSetSpec(deploy)
+			err = koe.SetSpec(deploy)
 			if err != nil {
 				t.Errorf("unexpected error in SetSpec: %v", err)
 			}
 
 			compareKubeObjectWithExpectedYaml(t, &koe.KubeObject, tc.expectedFile)
 		})
-	}
-}
-
-func TestSettersWithMissingFields(t *testing.T) {
-
-	type NoSpecOrStatus struct{}
-	var val NoSpecOrStatus
-
-	koe, err := NewFromGoStruct(val)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	err = koe.SafeSetSpec(val)
-	if err == nil {
-		t.Errorf("error was expected in SetSpec, but got no error")
-	}
-
-	err = koe.SafeSetStatus(val)
-	if err == nil {
-		t.Errorf("error was expected in SetStatus, but got no error")
 	}
 }
 
@@ -549,7 +528,7 @@ func TestKubeObjectExtSetStatus(t *testing.T) {
 
 			tc.transform(&deploy)
 
-			err = koe.SafeSetStatus(deploy)
+			err = koe.SetStatus(deploy)
 			if err != nil {
 				t.Errorf("unexpected error in SetStatus: %v", err)
 			}
@@ -557,4 +536,58 @@ func TestKubeObjectExtSetStatus(t *testing.T) {
 		})
 	}
 
+}
+
+func TestNewFromGoStructWithPointerType(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("NewFromGoStruct did NOT panic")
+		}
+	}()
+
+	_, _ = NewFromGoStruct(&appsv1.Deployment{})
+}
+
+func TestNewFromKubeObjectWithPointerType(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("NewFromKubeObject did NOT panic")
+		}
+	}()
+
+	_, _ = NewFromKubeObject[*appsv1.Deployment](nil)
+}
+
+func TestSetSpecWithMissingSpecField(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("SetSpec did NOT panic")
+		}
+	}()
+
+	type NoSpecOrStatus struct{}
+	var val NoSpecOrStatus
+
+	koe, err := NewFromGoStruct(val)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	_ = koe.SetSpec(val)
+}
+
+func TestSetStatusWithMissingStatusField(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("SetStatus did NOT panic")
+		}
+	}()
+
+	type NoSpecOrStatus struct{}
+	var val NoSpecOrStatus
+
+	koe, err := NewFromGoStruct(val)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	_ = koe.SetStatus(val)
 }

--- a/krm-functions/lib/vlanalloc/v1alpha1/vlanalloc.go
+++ b/krm-functions/lib/vlanalloc/v1alpha1/vlanalloc.go
@@ -17,8 +17,6 @@
 package v1alpha1
 
 import (
-	"fmt"
-
 	"github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
 	"github.com/nephio-project/nephio/krm-functions/lib/kubeobject"
 	vlanv1alpha1 "github.com/nokia/k8s-ipam/apis/alloc/vlan/v1alpha1"
@@ -51,10 +49,7 @@ func NewFromYAML(b []byte) (*VLANAllocation, error) {
 // NewFromGoStruct creates a new KubeObjectExt
 // It expects a go struct representing the KRM resource
 func NewFromGoStruct(x *vlanv1alpha1.VLANAllocation) (*VLANAllocation, error) {
-	if x == nil {
-		return nil, fmt.Errorf("cannot initialize with nil pointer")
-	}
-	r, err := kubeobject.NewFromGoStruct(*x)
+	r, err := kubeobject.NewFromGoStruct(x)
 	if err != nil {
 		return nil, err
 	}

--- a/krm-functions/lib/vlanalloc/v1alpha1/vlanalloc.go
+++ b/krm-functions/lib/vlanalloc/v1alpha1/vlanalloc.go
@@ -17,19 +17,21 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	"github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
 	"github.com/nephio-project/nephio/krm-functions/lib/kubeobject"
 	vlanv1alpha1 "github.com/nokia/k8s-ipam/apis/alloc/vlan/v1alpha1"
 )
 
 type VLANAllocation struct {
-	kubeobject.KubeObjectExt[*vlanv1alpha1.VLANAllocation]
+	kubeobject.KubeObjectExt[vlanv1alpha1.VLANAllocation]
 }
 
 // NewFromKubeObject creates a new KubeObjectExt
 // It expects a *fn.KubeObject as input representing the serialized yaml file
 func NewFromKubeObject(o *fn.KubeObject) (*VLANAllocation, error) {
-	r, err := kubeobject.NewFromKubeObject[*vlanv1alpha1.VLANAllocation](o)
+	r, err := kubeobject.NewFromKubeObject[vlanv1alpha1.VLANAllocation](o)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +41,7 @@ func NewFromKubeObject(o *fn.KubeObject) (*VLANAllocation, error) {
 // NewFromYAML creates a new KubeObjectExt
 // It expects a raw byte slice as input representing the serialized yaml file
 func NewFromYAML(b []byte) (*VLANAllocation, error) {
-	r, err := kubeobject.NewFromYaml[*vlanv1alpha1.VLANAllocation](b)
+	r, err := kubeobject.NewFromYaml[vlanv1alpha1.VLANAllocation](b)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +51,10 @@ func NewFromYAML(b []byte) (*VLANAllocation, error) {
 // NewFromGoStruct creates a new KubeObjectExt
 // It expects a go struct representing the KRM resource
 func NewFromGoStruct(x *vlanv1alpha1.VLANAllocation) (*VLANAllocation, error) {
-	r, err := kubeobject.NewFromGoStruct[*vlanv1alpha1.VLANAllocation](x)
+	if x == nil {
+		return nil, fmt.Errorf("cannot initialize with nil pointer")
+	}
+	r, err := kubeobject.NewFromGoStruct(*x)
 	if err != nil {
 		return nil, err
 	}
@@ -57,9 +62,9 @@ func NewFromGoStruct(x *vlanv1alpha1.VLANAllocation) (*VLANAllocation, error) {
 }
 
 func (r *VLANAllocation) SetSpec(spec vlanv1alpha1.VLANAllocationSpec) error {
-	return r.KubeObjectExt.SetSpec(spec)
+	return r.KubeObjectExt.UnsafeSetSpec(spec)
 }
 
 func (r *VLANAllocation) SetStatus(spec vlanv1alpha1.VLANAllocationStatus) error {
-	return r.KubeObjectExt.SetStatus(spec)
+	return r.KubeObjectExt.UnsafeSetStatus(spec)
 }

--- a/krm-functions/lib/vlanalloc/v1alpha1/vlanalloc_test.go
+++ b/krm-functions/lib/vlanalloc/v1alpha1/vlanalloc_test.go
@@ -107,7 +107,7 @@ func TestNewFromGoStruct(t *testing.T) {
 		},
 		"Nil": {
 			input:       nil,
-			errExpected: false, // new approach does not return an error
+			errExpected: true,
 		},
 	}
 


### PR DESCRIPTION
- Rename SetSpec and SetStatus Implementations
- Validate type parameter (T1)
- Refactor libs to match the new KubeObjectExt API

The type parameter validation will only allow struct types to be used as the KubeObjectExt[T1] type parameter, however all structs are passed by pointers in all methods.