### PR TITLE
Use regular build, without the replace

### DIFF
--- a/operators/nephio-controller-manager/go.mod
+++ b/operators/nephio-controller-manager/go.mod
@@ -8,10 +8,10 @@ replace k8s.io/apimachinery => k8s.io/apimachinery v0.26.1
 
 replace k8s.io/client-go => k8s.io/client-go v0.26.1
 
-replace github.com/nephio-project/nephio/controllers/pkg => ../../controllers/pkg
+//replace github.com/nephio-project/nephio/controllers/pkg => ../../controllers/pkg
 
 require (
-	github.com/nephio-project/nephio/controllers/pkg v0.0.0-20230527153803-31b37fcf142b
+	github.com/nephio-project/nephio/controllers/pkg v0.0.0-20230530171006-1c3077369abd
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2

--- a/operators/nephio-controller-manager/go.sum
+++ b/operators/nephio-controller-manager/go.sum
@@ -143,6 +143,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/nephio-project/api v0.0.0-20230522173958-63a41669b495 h1:lKibqCJw7x5XKwev43GNGeEJwbx9twlVSLu2l5nDZBo=
 github.com/nephio-project/api v0.0.0-20230522173958-63a41669b495/go.mod h1:v2DHagSVdoKQxQXFBwGw0VWvvmw5EFNJ0JuFjhwsGwM=
+github.com/nephio-project/nephio/controllers/pkg v0.0.0-20230530171006-1c3077369abd h1:37hQwQb1ng99AiJy0bYVqvnO33/TBi/BCQr7tCg9aYA=
+github.com/nephio-project/nephio/controllers/pkg v0.0.0-20230530171006-1c3077369abd/go.mod h1:rvsHiqd0DuQiJmxlJfDQU7U8JPPdexPVn5RDs05vlgU=
 github.com/nephio-project/nephio/krm-functions/ipam-fn v0.0.0-20230519080401-f95bbb7f58a6 h1:4Im540v27uiAt7pLaXsHvjq+bPjo6yW6I1cmxhqP7iA=
 github.com/nephio-project/nephio/krm-functions/ipam-fn v0.0.0-20230519080401-f95bbb7f58a6/go.mod h1:f8MW/xm4uKycEAspdsVN9KBpmRbPtiTak+Kj00LGL1A=
 github.com/nephio-project/nephio/krm-functions/lib v0.0.0-20230508215739-b13457eda5c9 h1:fWHt9kSXIHLfA5rc77iiRUsmshFmm5hqWmmvsPAvVuw=


### PR DESCRIPTION
The last PR merged, so now the changes to pkg are available for consumption by the separate operator module. Change the operator module to use those.

This is not great, we should figure out a better package structure, or figure out Go workspaces.