### PR TITLE
Add a check for deltas before saving

### DIFF
--- a/controllers/pkg/porch/util/packagerevision.go
+++ b/controllers/pkg/porch/util/packagerevision.go
@@ -1,0 +1,35 @@
+/*
+ Copyright 2023 The Nephio Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+
+	porchv1alpha1 "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+func PackageRevisionResourcesHash(prr *porchv1alpha1.PackageRevisionResources) (string, error) {
+	b, err := yaml.Marshal(prr.Spec.Resources)
+	if err != nil {
+		return "", err
+	}
+	hash := sha1.Sum(b)
+	return hex.EncodeToString(hash[:]), nil
+}

--- a/controllers/pkg/porch/util/packagerevision.go
+++ b/controllers/pkg/porch/util/packagerevision.go
@@ -17,7 +17,6 @@
 package util
 
 import (
-	"context"
 	"crypto/sha1"
 	"encoding/hex"
 

--- a/controllers/pkg/porch/util/packagerevision.go
+++ b/controllers/pkg/porch/util/packagerevision.go
@@ -17,7 +17,7 @@
 package util
 
 import (
-	"crypto/sha1"
+	"crypto/sha512"
 	"encoding/hex"
 
 	porchv1alpha1 "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
@@ -29,6 +29,6 @@ func PackageRevisionResourcesHash(prr *porchv1alpha1.PackageRevisionResources) (
 	if err != nil {
 		return "", err
 	}
-	hash := sha1.Sum(b)
+	hash := sha512.Sum512(b)
 	return hex.EncodeToString(hash[:]), nil
 }

--- a/controllers/pkg/reconcilers/generic-specializer/reconciler.go
+++ b/controllers/pkg/reconcilers/generic-specializer/reconciler.go
@@ -254,12 +254,15 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			for _, c := range kptfile.Status.Conditions {
 				if strings.HasPrefix(c.Type, kptfilelibv1.GetConditionType(&r.vlanFor)+".") ||
 					strings.HasPrefix(c.Type, kptfilelibv1.GetConditionType(&r.ipamFor)+".") {
-					r.l.Info("generic specializer conditions", "cluserName", clusterName, "status", c.Status, "condition", c.Type)
+					r.l.Info("generic specializer conditions", "clusterName", clusterName, "status", c.Status, "condition", c.Type)
 				}
 			}
 		}
 	}
 
+	/*
+	* jbelamaric: Since we never save the PR, I don't think this does anything?
+	*
 	kptfile := rl.Items.GetRootKptfile()
 	if kptfile == nil {
 		r.recorder.Event(pr, corev1.EventTypeWarning, "ReconcileError", "mandatory Kptfile is missing")
@@ -274,6 +277,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 	pr.Status.Conditions = porchcondition.GetPorchConditions(kptf.GetConditions())
+	*/
 
 	afterHash, err := porchutil.PackageRevisionResourcesHash(prr)
 	if err != nil {

--- a/controllers/pkg/reconcilers/generic-specializer/reconciler.go
+++ b/controllers/pkg/reconcilers/generic-specializer/reconciler.go
@@ -149,7 +149,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{}, errors.Wrap(err, "cannot get package revision resources")
 		}
 
-		beforeHash, err := util.PackageRevisionResourcesHash(prr)
+		beforeHash, err := porchutil.PackageRevisionResourcesHash(prr)
 		if err != nil {
 			r.recorder.Event(pr, corev1.EventTypeWarning, "ReconcileError", fmt.Sprintf("cannot calculate pre-reconcile hash: %s", err.Error()))
 			r.l.Error(err, "cannot calculate pre-reconcile hash")
@@ -270,7 +270,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 		pr.Status.Conditions = porchcondition.GetPorchConditions(kptf.GetConditions())
 
-		afterHash, err := util.PackageRevisionResourcesHash(prr)
+		afterHash, err := porchutil.PackageRevisionResourcesHash(prr)
 		if err != nil {
 			r.recorder.Event(pr, corev1.EventTypeWarning, "ReconcileError", fmt.Sprintf("cannot calculate post-reconcile hash: %s", err.Error()))
 			r.l.Error(err, "cannot calculate post-reconcile hash")


### PR DESCRIPTION
The auto-approval controller was not kicking in, because the PackageRevision creation timestamp kept updating. Which is odd, and probably a bug in Porch. But, we want this anyway. It will avoid saving the package revision resources if there is no delta. This should prevent the forever growing task list, hopefully.

Still testing - one concern is that if we are refreshing claims, we may be stuffing away a timestamp which means this would never find matching hashes.