### PR TITLE
Minor fixes and cosmetics around Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,24 +32,30 @@ GO_MOD_DIRS = $(shell find . -name 'go.mod' -printf "'%h' ")
 # find all subdirectories with a Dockerfile in them
 DOCKERFILE_DIRS = $(shell find . -iname 'Dockerfile' -printf "'%h' " )
 
+# This includes the 'help' target that prints out all targets with their descriptions organized by categories
+include default-help.mk
+
+
+##@ Go tests & formatting
 
 .PHONY: unit lint gosec test unit-clean 
-# delegate these targets to the Makefiles of individual go modules
-unit lint gosec test: 
+unit lint gosec test: ## These targets are delegated to the Makefiles of individual Go modules
 	for dir in $(GO_MOD_DIRS); do \
 		$(MAKE) -C "$$dir" $@ ; \
 	done
 
 # delegate these targets to the Makefiles of individual go modules, 
-# but skip the module if the target doesn't exists, or an error happened
-unit-clean : 
+# but simply skip the module if the target doesn't exists, or if an error happened
+unit-clean: ## These targets are delegated to the Makefiles of individual Go modules
 	for dir in $(GO_MOD_DIRS); do \
 		$(MAKE) -C "$$dir" $@ || true ; \
 	done
 
+
+##@ Container images
+
 .PHONY: docker-build docker-push
-# delegate these targets to the Makefiles next to Dockerfiles
-docker-build docker-push: 
+docker-build docker-push: ## These targets are delegated to the Makefiles next to Dockerfiles
 	for dir in $(DOCKERFILE_DIRS); do \
 		$(MAKE) -C "$$dir" $@  ; \
 	done

--- a/controllers/pkg/Makefile
+++ b/controllers/pkg/Makefile
@@ -1,3 +1,16 @@
+#  Copyright 2023 The Nephio Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 
 .PHONY: all
 all: fmt test
@@ -7,3 +20,6 @@ all: fmt test
 #   gosec, lint,
 #   fmt, vet,
 include ../../default-go.mk
+
+# This includes the 'help' target that prints out all targets with their descriptions organized by categories
+include ../../default-help.mk

--- a/default-docker.mk
+++ b/default-docker.mk
@@ -23,11 +23,12 @@ endif
 
 endif
 
+##@ Container images
 
 .PHONY: docker-build
-docker-build:  ## Build docker image
+docker-build:  ## Build a container image from the local Dockerfile
 	$(CONTAINER_RUNTIME) buildx build --load --tag  ${IMG} -f ./Dockerfile "$(self_dir)"
 
 .PHONY: docker-push
-docker-push: docker-build ## Build and push docker image
+docker-push: docker-build ## Build and push the container image
 	$(CONTAINER_RUNTIME) push ${IMG}

--- a/default-go-lint.mk
+++ b/default-go-lint.mk
@@ -17,7 +17,7 @@ GOLANG_CI_VER ?= v1.52
 
 # Install link at https://golangci-lint.run/usage/install/ if not running inside a container
 .PHONY: lint
-lint: ## Run lint  against code.
+lint: ## Run Go linter against the codebase
 ifeq ($(CONTAINER_RUNNABLE), 0)
 		$(CONTAINER_RUNTIME) run -it -v "$(CURDIR):/go/src" -w /go/src docker.io/golangci/golangci-lint:${GOLANG_CI_VER}-alpine \
 		 golangci-lint run ./... -v --timeout 10m

--- a/default-go-misc.mk
+++ b/default-go-misc.mk
@@ -13,9 +13,9 @@
 #  limitations under the License.
 
 .PHONY: fmt
-fmt: ## Run go fmt against code.
+fmt: ## Run go fmt against the codebase
 	go fmt ./...
 
 .PHONY: vet
-vet: ## Run go vet against code.
+vet: ## Run go vet against the codebase
 	go vet ./...

--- a/default-go-test.mk
+++ b/default-go-test.mk
@@ -21,7 +21,7 @@ TEST_COVERAGE_FUNC_FILE=func_coverage.out
 unit: test
 
 .PHONY: test
-test: ## Run unit tests against code.
+test: ## Run unit tests (go test)
 ifeq ($(CONTAINER_RUNNABLE), 0)
 		$(CONTAINER_RUNTIME) run -it -v "$(CURDIR):/go/src" -w /go/src docker.io/library/golang:${GO_VERSION}-alpine3.17 \
          sh -e -c "go test ./... -v -coverprofile ${TEST_COVERAGE_FILE}; \
@@ -34,7 +34,7 @@ else
 endif
 
 .PHONY: unit-clean
-unit-clean: ## clean up the unit test artifacts created
+unit-clean: ## Clean up the artifacts created by the unit tests
 ifeq ($(CONTAINER_RUNNABLE), 0)
 		$(CONTAINER_RUNTIME) system prune -f
 endif

--- a/default-go.mk
+++ b/default-go.mk
@@ -12,6 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+
+##@ Go tests & formatting
+
 self_dir := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(self_dir)/default-go-misc.mk 
 include $(self_dir)/default-go-test.mk 

--- a/default-gosec.mk
+++ b/default-gosec.mk
@@ -16,7 +16,7 @@ GOSEC_VER ?= 2.15.0
 
 # Install link at https://github.com/securego/gosec#install if not running inside a container
 .PHONY: gosec
-gosec: ## inspects source code for security problem by scanning the Go Abstract Syntax Tree
+gosec: ## Inspect the source code for security problems by scanning the Go Abstract Syntax Tree
 ifeq ($(CONTAINER_RUNNABLE), 0)
 		$(CONTAINER_RUNTIME) run -it -v "$(CURDIR):/go/src" -w /go/src docker.io/securego/gosec:${GOSEC_VER} ./...
 else

--- a/default-help.mk
+++ b/default-help.mk
@@ -1,0 +1,30 @@
+#  Copyright 2023 The Nephio Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+##@ General
+
+# The help target prints out all targets with their descriptions organized
+# beneath their categories. The categories are represented by '##@' and the
+# target descriptions by '##'. The awk commands is responsible for reading the
+# entire set of makefiles included in this invocation, looking for lines of the
+# file as xyz: ## something, and then pretty-format the target and help. Then,
+# if there's a line with ##@ something, that gets pretty-printed as a category.
+# More info on the usage of ANSI control characters for terminal formatting:
+# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
+# More info on the awk command:
+# http://linuxcommand.org/lc3_adv_awk.php
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[ a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/krm-functions/Makefile
+++ b/krm-functions/Makefile
@@ -19,6 +19,9 @@ GO_MOD_DIRS = $(shell find . -name 'go.mod' -printf "'%h' ")
 # find all subdirectories with a Dockerfile in them
 DOCKERFILE_DIRS = $(shell find . -iname 'Dockerfile' -printf "'%h' " )
 
+# This includes the 'help' target that prints out all targets with their descriptions organized by categories
+include ../../default-help.mk
+
 .PHONY: docker-build docker-push
 docker-build docker-push:  ## Build docker images.
 	for dir in $(DOCKERFILE_DIRS); do \

--- a/krm-functions/Makefile
+++ b/krm-functions/Makefile
@@ -11,15 +11,13 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-GO_VERSION ?= 1.20.2
-VERSION ?= latest
-REGISTRY ?= docker.io/nephio
+
+.SHELLFLAGS = -ec
 
 # find all subdirectories with a go.mod file in them
 GO_MOD_DIRS = $(shell find . -name 'go.mod' -printf "'%h' ")
 # find all subdirectories with a Dockerfile in them
 DOCKERFILE_DIRS = $(shell find . -iname 'Dockerfile' -printf "'%h' " )
-
 
 .PHONY: docker-build docker-push
 docker-build docker-push:  ## Build docker images.

--- a/krm-functions/dnn-fn/Makefile
+++ b/krm-functions/dnn-fn/Makefile
@@ -13,5 +13,8 @@ include ../../default-go.mk
 #   docker-build, docker-push
 include ../../default-docker.mk
 
+# This includes the 'help' target that prints out all targets with their descriptions organized by categories
+include ../../default-help.mk
+
 .PHONY: all
 all: fmt test docker-build docker-push

--- a/krm-functions/interface-fn/Makefile
+++ b/krm-functions/interface-fn/Makefile
@@ -13,5 +13,8 @@ include ../../default-go.mk
 #   docker-build, docker-push
 include ../../default-docker.mk
 
+# This includes the 'help' target that prints out all targets with their descriptions organized by categories
+include ../../default-help.mk
+
 .PHONY: all
 all: fmt test docker-build docker-push

--- a/krm-functions/ipam-fn/Makefile
+++ b/krm-functions/ipam-fn/Makefile
@@ -13,5 +13,8 @@ include ../../default-go.mk
 #   docker-build, docker-push
 include ../../default-docker.mk
 
+# This includes the 'help' target that prints out all targets with their descriptions organized by categories
+include ../../default-help.mk
+
 .PHONY: all
 all: fmt test docker-build docker-push

--- a/krm-functions/lib/Makefile
+++ b/krm-functions/lib/Makefile
@@ -7,3 +7,6 @@ all: fmt test
 #   gosec, lint,
 #   fmt, vet,
 include ../../default-go.mk
+
+# This includes the 'help' target that prints out all targets with their descriptions organized by categories
+include ../../default-help.mk

--- a/krm-functions/nad-fn/Makefile
+++ b/krm-functions/nad-fn/Makefile
@@ -13,5 +13,8 @@ include ../../default-go.mk
 #   docker-build, docker-push
 include ../../default-docker.mk
 
+# This includes the 'help' target that prints out all targets with their descriptions organized by categories
+include ../../default-help.mk
+
 .PHONY: all
 all: fmt test docker-build docker-push

--- a/krm-functions/nfdeploy-fn/Makefile
+++ b/krm-functions/nfdeploy-fn/Makefile
@@ -1,3 +1,20 @@
+#  Copyright 2023 The Nephio Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+.SHELLFLAGS = -ec
+
+# find all subdirectories with a Dockerfile in them
 DOCKERFILE_DIRS = $(shell find . -iname 'Dockerfile' -printf "'%h' " )
 
 # This includes the following targets:
@@ -6,18 +23,21 @@ DOCKERFILE_DIRS = $(shell find . -iname 'Dockerfile' -printf "'%h' " )
 #   fmt, vet
 include ../../default-go.mk
 
+# This includes the 'help' target that prints out all targets with their descriptions organized by categories
+include ../../default-help.mk
+
 .PHONY: all
 all: fmt test docker-build docker-push
 
-
+##@ Container images
 
 .PHONY: docker-build docker-push
-docker-build: fmt test
+docker-build: fmt test ## Build container images.
 	for dir in $(DOCKERFILE_DIRS); do \
 		$(MAKE) -C "$$dir" $@  ; \
 	done
 
-docker-push: 
+docker-push: ## Push container images.
 	for dir in $(DOCKERFILE_DIRS); do \
 		$(MAKE) -C "$$dir" $@  ; \
 	done

--- a/krm-functions/nfdeploy-fn/amfdeployfn/Makefile
+++ b/krm-functions/nfdeploy-fn/amfdeployfn/Makefile
@@ -6,3 +6,6 @@ IMG ?= $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
 # This includes the following targets:
 #   docker-build, docker-push
 include ../../../default-docker.mk
+
+# This includes the 'help' target that prints out all targets with their descriptions organized by categories
+include ../../default-help.mk

--- a/krm-functions/nfdeploy-fn/smfdeployfn/Makefile
+++ b/krm-functions/nfdeploy-fn/smfdeployfn/Makefile
@@ -6,3 +6,6 @@ IMG ?= $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
 # This includes the following targets:
 #   docker-build, docker-push
 include ../../../default-docker.mk
+
+# This includes the 'help' target that prints out all targets with their descriptions organized by categories
+include ../../default-help.mk

--- a/krm-functions/nfdeploy-fn/upfdeployfn/Makefile
+++ b/krm-functions/nfdeploy-fn/upfdeployfn/Makefile
@@ -6,3 +6,6 @@ IMG ?= $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
 # This includes the following targets:
 #   docker-build, docker-push
 include ../../../default-docker.mk
+
+# This includes the 'help' target that prints out all targets with their descriptions organized by categories
+include ../../default-help.mk

--- a/krm-functions/pipeline-tests/Makefile
+++ b/krm-functions/pipeline-tests/Makefile
@@ -7,3 +7,6 @@ all: fmt test
 #   gosec, lint,
 #   fmt, vet,
 include ../../default-go.mk
+
+# This includes the 'help' target that prints out all targets with their descriptions organized by categories
+include ../../default-help.mk

--- a/krm-functions/vlan-fn/Makefile
+++ b/krm-functions/vlan-fn/Makefile
@@ -13,5 +13,8 @@ include ../../default-go.mk
 #   docker-build, docker-push
 include ../../default-docker.mk
 
+# This includes the 'help' target that prints out all targets with their descriptions organized by categories
+include ../../default-help.mk
+
 .PHONY: all
 all: fmt test docker-build docker-push

--- a/operators/nephio-controller-manager/Makefile
+++ b/operators/nephio-controller-manager/Makefile
@@ -90,26 +90,6 @@ docker-build-local: test build ## Build locally, copy in manager to image
 docker-push-local: ## Push docker image with the manager.
 	docker push ${IMGLOCAL}
 
-.PHONY: unit_clean
-unit_clean: ## clean up the unit test artifacts created
-ifeq ($(CONTAINER_RUNNABLE), 0)
-		$(CONTAINER_RUNTIME) system prune -f
-endif
-		rm ${TEST_COVERAGE_FILE} ${TEST_COVERAGE_HTML_FILE} ${TEST_COVERAGE_FUNC_FILE} > /dev/null 2>&1
-
-.PHONY: unit
-unit: ## Run unit tests against code.
-ifeq ($(CONTAINER_RUNNABLE), 0)
-		$(CONTAINER_RUNTIME) run -it -v ${PWD}:/go/src -w /go/src docker.io/library/golang:${GO_VERSION}-alpine3.17 \
-         go test ./... -v -coverprofile ${TEST_COVERAGE_FILE}; \
-         go tool cover -html=${TEST_COVERAGE_FILE} -o ${TEST_COVERAGE_HTML_FILE}; \
-         go tool cover -func=${TEST_COVERAGE_FILE} -o ${TEST_COVERAGE_FUNC_FILE}
-else
-		go test ./... -v -coverprofile ${TEST_COVERAGE_FILE}
-		go tool cover -html=${TEST_COVERAGE_FILE} -o ${TEST_COVERAGE_HTML_FILE} 
-		go tool cover -func=${TEST_COVERAGE_FILE} -o ${TEST_COVERAGE_FUNC_FILE}
-endif
-
 # PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
 # architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
 # - able to use docker buildx . More info: https://docs.docker.com/build/buildx/

--- a/operators/nephio-controller-manager/Makefile
+++ b/operators/nephio-controller-manager/Makefile
@@ -17,7 +17,6 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-.PHONY: all
 # This includes the following targets:
 #   test, unit, unit-clean,
 #   gosec, lint,
@@ -28,6 +27,7 @@ include ../../default-go.mk
 #   docker-build, docker-push
 include ../../default-docker.mk
 
+.PHONY: all
 all: build
 
 ##@ General


### PR DESCRIPTION
The most important fix is that `make test` didn't fail in krm-functions/Makefile if one of the sub-make tests failed