### PR TITLE
Faster approvals for the auto-approve controller

### DIFF
--- a/controllers/pkg/reconcilers/approval/reconciler_test.go
+++ b/controllers/pkg/reconcilers/approval/reconciler_test.go
@@ -1,0 +1,149 @@
+// Copyright 2023 The Nephio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package approval
+
+import (
+	"testing"
+	"time"
+
+	porchapi "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestShouldProcess(t *testing.T) {
+	testCases := map[string]struct {
+		pr             porchapi.PackageRevision
+		expectedPolicy string
+		expectedShould bool
+	}{
+		"draft with no annotation": {
+			pr:             porchapi.PackageRevision{},
+			expectedPolicy: "",
+			expectedShould: false,
+		},
+		"draft with policy annotation": {
+			pr: porchapi.PackageRevision{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"approval.nephio.org/policy": "initial",
+					},
+				},
+			},
+			expectedPolicy: "initial",
+			expectedShould: true,
+		},
+		"draft with no policy annotation, but delay annotation": {
+			pr: porchapi.PackageRevision{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"approval.nephio.org/delay": "20s",
+					},
+				},
+			},
+			expectedPolicy: "",
+			expectedShould: false,
+		},
+		"published with policy annotation": {
+			pr: porchapi.PackageRevision{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"approval.nephio.org/policy": "initial",
+					},
+				},
+				Spec: porchapi.PackageRevisionSpec{
+					Lifecycle: "Published",
+				},
+			},
+			expectedPolicy: "initial",
+			expectedShould: false,
+		},
+	}
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			actualPolicy, actualShould := shouldProcess(&tc.pr)
+			require.Equal(t, tc.expectedPolicy, actualPolicy)
+			require.Equal(t, tc.expectedShould, actualShould)
+		})
+	}
+}
+
+func TestManageDelay(t *testing.T) {
+	now := time.Now()
+	testCases := map[string]struct {
+		pr             porchapi.PackageRevision
+		expectedRequeue bool
+		expectedError bool
+	}{
+		"no annotation": {
+			pr:             porchapi.PackageRevision{},
+			expectedRequeue: false,
+			expectedError: false,
+		},
+		"unparseable annotation": {
+			pr: porchapi.PackageRevision{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"approval.nephio.org/delay": "foo",
+					},
+				},
+			},
+			expectedRequeue: false,
+			expectedError: true,
+		},
+		"negative annotation": {
+			pr: porchapi.PackageRevision{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"approval.nephio.org/delay": "-5s",
+					},
+				},
+			},
+			expectedRequeue: false,
+			expectedError: true,
+		},
+		"not old enough": {
+			pr: porchapi.PackageRevision{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Time{now},
+					Annotations: map[string]string{
+						"approval.nephio.org/delay": "1h",
+					},
+				},
+			},
+			expectedRequeue: true,
+			expectedError: false,
+		},
+		"old enough": {
+			pr: porchapi.PackageRevision{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Time{now.AddDate(-1,0,0)},
+					Annotations: map[string]string{
+						"approval.nephio.org/delay": "1h",
+					},
+				},
+			},
+			expectedRequeue: false,
+			expectedError: false,
+		},
+	}
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			actualRequeue, actualError := manageDelay(&tc.pr)
+			require.Equal(t, tc.expectedRequeue, actualRequeue > 0)
+			require.Equal(t, tc.expectedError, actualError != nil)
+		})
+	}
+}


### PR DESCRIPTION
There is now no longer a default delay; it only delays if you specifically give a delay annotation.

The minimum delay is now 0.

Re-ordered the checks so that the delay will not come into play unless all other checks are already met.

Added some tests.