### PR TITLE
De duplication logic to NF Deploy Fn Param Ref

### DIFF
--- a/krm-functions/nfdeploy-fn/fn/function.go
+++ b/krm-functions/nfdeploy-fn/fn/function.go
@@ -259,6 +259,12 @@ func (f *NfDeployFn) UpdateResourceFn(nfDeploymentObj *fn.KubeObject, objs fn.Ku
 		return nil, err
 	}
 
+	// add all the existing param ref to the struct
+	// we need to compare for deduplication logic
+	// slice append is not ideal, it breaks the function idempotency requirement
+	f.paramRef = nf.Spec.ParametersRefs
+	fn.Logf("Before elements in paramRef %+v", nf.Spec.ParametersRefs)
+
 	capObjs := objs.Where(fn.IsGroupVersionKind(nephioreqv1alpha1.CapacityGroupVersionKind))
 	for _, o := range capObjs {
 		if err := f.CapacityUpdate(o); err != nil {
@@ -271,6 +277,7 @@ func (f *NfDeployFn) UpdateResourceFn(nfDeploymentObj *fn.KubeObject, objs fn.Ku
 			return nil, err
 		}
 	}
+
 	itfceObjs := objs.Where(fn.IsGroupVersionKind(nephioreqv1alpha1.InterfaceGroupVersionKind))
 	for _, o := range itfceObjs {
 		if err := f.InterfaceUpdate(o); err != nil {
@@ -287,11 +294,8 @@ func (f *NfDeployFn) UpdateResourceFn(nfDeploymentObj *fn.KubeObject, objs fn.Ku
 
 	f.FillCapacityDetails(nf)
 
-	if len(nf.Spec.ParametersRefs) == 0 {
-		nf.Spec.ParametersRefs = f.paramRef
-	} else {
-		nf.Spec.ParametersRefs = append(nf.Spec.ParametersRefs, f.paramRef...)
-	}
+	nf.Spec.ParametersRefs = f.paramRef
+	fn.Logf("Af elements in paramRef %+v", nf.Spec.ParametersRefs)
 
 	//sort the paramRefs
 	sort.Slice(nf.Spec.ParametersRefs, func(i, j int) bool {

--- a/krm-functions/nfdeploy-fn/fn/function.go
+++ b/krm-functions/nfdeploy-fn/fn/function.go
@@ -263,7 +263,6 @@ func (f *NfDeployFn) UpdateResourceFn(nfDeploymentObj *fn.KubeObject, objs fn.Ku
 	// we need to compare for deduplication logic
 	// slice append is not ideal, it breaks the function idempotency requirement
 	f.paramRef = nf.Spec.ParametersRefs
-	fn.Logf("Before elements in paramRef %+v", nf.Spec.ParametersRefs)
 
 	capObjs := objs.Where(fn.IsGroupVersionKind(nephioreqv1alpha1.CapacityGroupVersionKind))
 	for _, o := range capObjs {
@@ -295,7 +294,6 @@ func (f *NfDeployFn) UpdateResourceFn(nfDeploymentObj *fn.KubeObject, objs fn.Ku
 	f.FillCapacityDetails(nf)
 
 	nf.Spec.ParametersRefs = f.paramRef
-	fn.Logf("Af elements in paramRef %+v", nf.Spec.ParametersRefs)
 
 	//sort the paramRefs
 	sort.Slice(nf.Spec.ParametersRefs, func(i, j int) bool {

--- a/krm-functions/nfdeploy-fn/fn/helper.go
+++ b/krm-functions/nfdeploy-fn/fn/helper.go
@@ -121,9 +121,20 @@ func (h *NfDeployFn) FillCapacityDetails(nf *workloadv1alpha1.NFDeployment) {
 }
 
 func (h *NfDeployFn) AddDependencyRef(ref corev1.ObjectReference) {
-	h.paramRef = append(h.paramRef, workloadv1alpha1.ObjectReference{
-		Name:       &ref.Name,
-		Kind:       ref.Kind,
-		APIVersion: ref.APIVersion,
-	})
+	if !h.checkDependencyExist(ref) {
+		h.paramRef = append(h.paramRef, workloadv1alpha1.ObjectReference{
+			Name:       &ref.Name,
+			Kind:       ref.Kind,
+			APIVersion: ref.APIVersion,
+		})
+	}
+}
+
+func (h *NfDeployFn) checkDependencyExist(ref corev1.ObjectReference) bool {
+	for _, p := range h.paramRef {
+		if *p.Name == ref.Name && p.Kind == ref.Kind && p.APIVersion == ref.APIVersion {
+			return true
+		}
+	}
+	return false
 }

--- a/krm-functions/nfdeploy-fn/fn/testdata/golden/nfdeployment_witthduplicatedependency/Kptfile
+++ b/krm-functions/nfdeploy-fn/fn/testdata/golden/nfdeployment_witthduplicatedependency/Kptfile
@@ -1,0 +1,30 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: cluster01-amf
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: amf package example
+pipeline: {}
+status:
+  conditions:
+  - message: update condition for initial resource
+    reason: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
+    status: "True"
+    type: req.nephio.org/v1alpha1.Capacity.dataplane
+  - message: update condition for initial resource
+    reason: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
+    status: "True"
+    type: req.nephio.org/v1alpha1.DataNetwork.internet
+  - message: update condition for initial resource
+    reason: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
+    status: "True"
+    type: req.nephio.org/v1alpha1.Interface.n2
+  - message: update for condition
+    status: "False"
+    type: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
+  - message: update condition for initial resource
+    reason: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
+    status: "True"
+    type: req.nephio.org/v1alpha1.Dependency.upf

--- a/krm-functions/nfdeploy-fn/fn/testdata/golden/nfdeployment_witthduplicatedependency/Kptfile
+++ b/krm-functions/nfdeploy-fn/fn/testdata/golden/nfdeployment_witthduplicatedependency/Kptfile
@@ -28,3 +28,7 @@ status:
     reason: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
     status: "True"
     type: req.nephio.org/v1alpha1.Dependency.upf
+  - message: update condition for initial resource
+    reason: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
+    status: "True"
+    type: req.nephio.org/v1alpha1.Dependency.upf_duplicate

--- a/krm-functions/nfdeploy-fn/fn/testdata/golden/nfdeployment_witthduplicatedependency/_expected.yaml
+++ b/krm-functions/nfdeploy-fn/fn/testdata/golden/nfdeployment_witthduplicatedependency/_expected.yaml
@@ -1,0 +1,139 @@
+apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+items:
+- apiVersion: infra.nephio.org/v1alpha1
+  kind: WorkloadCluster
+  metadata:
+    name: cluster01
+    annotations:
+      config.kubernetes.io/local-config: "true"
+  spec:
+    clusterName: cluster01
+    cnis:
+    - macvlan
+    - ipvlan
+    - sriov
+    masterInterface: eth1
+- apiVersion: kpt.dev/v1
+  kind: Kptfile
+  metadata:
+    name: cluster01-amf
+    annotations:
+      config.kubernetes.io/local-config: "true"
+  info:
+    description: amf package example
+    readinessGates:
+    - conditionType: nephio.org.Specializer.specialize
+  pipeline: {}
+  status:
+    conditions:
+    - message: update condition for initial resource
+      reason: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
+      status: "True"
+      type: req.nephio.org/v1alpha1.Capacity.dataplane
+    - message: update condition for initial resource
+      reason: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
+      status: "True"
+      type: req.nephio.org/v1alpha1.DataNetwork.internet
+    - message: update condition for initial resource
+      reason: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
+      status: "True"
+      type: req.nephio.org/v1alpha1.Interface.n2
+    - message: update for condition
+      status: "False"
+      type: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
+    - message: update condition for initial resource
+      reason: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
+      status: "True"
+      type: req.nephio.org/v1alpha1.Dependency.upf
+    - message: not ready
+      reason: Specialize
+      status: "False"
+      type: nephio.org.Specializer.specialize
+    - message: create initial resource condition
+      reason: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
+      status: "False"
+      type: req.nephio.org/v1alpha1.Dependency.upf_duplicate
+- apiVersion: req.nephio.org/v1alpha1
+  kind: Capacity
+  metadata:
+    name: dataplane
+    annotations:
+      config.kubernetes.io/local-config: "true"
+      specializer.nephio.org/owner: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
+  spec:
+    maxUplinkThroughput: 0
+    maxSubscribers: 1000
+    maxDownlinkThroughput: 0
+- apiVersion: req.nephio.org/v1alpha1
+  kind: DataNetwork
+  metadata:
+    name: internet
+    annotations:
+      config.kubernetes.io/local-config: "true"
+      prefix: 10.0.0.0/8
+      specializer.nephio.org/owner: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
+  spec:
+  status: {}
+- apiVersion: req.nephio.org/v1alpha1
+  kind: Dependency
+  metadata:
+    name: upf
+    annotations:
+      specializer.nephio.org/owner: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
+      specializer.nephio.org/namespace: free5gc-cp
+  spec:
+    packageName: free5gc-upf
+    injectors:
+    - apiVersion: workload.nephio.org/v1alpha1
+      kind: NFDeployment
+  status:
+    injected:
+    - name: amf-regional-upf-edge02
+      namespace: free5gc-cp
+      apiVersion: ref.nephio.org/v1alpha1
+      kind: Config
+- apiVersion: req.nephio.org/v1alpha1
+  kind: Dependency
+  metadata:
+    name: upf_duplicate
+    annotations:
+      specializer.nephio.org/owner: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
+      specializer.nephio.org/namespace: free5gc-cp
+  spec:
+    packageName: free5gc-upf
+    injectors:
+    - apiVersion: workload.nephio.org/v1alpha1
+      kind: NFDeployment
+  status:
+    injected:
+    - name: amf-regional-upf-edge02
+      namespace: free5gc-cp
+      apiVersion: ref.nephio.org/v1alpha1
+      kind: Config
+- apiVersion: req.nephio.org/v1alpha1
+  kind: Interface
+  metadata:
+    name: n2
+    annotations:
+      config.kubernetes.io/local-config: "true"
+      specializer.nephio.org/owner: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
+  spec:
+    networkInstance:
+      name: vpc-ran
+    cniType: sriov
+    attachmentType: vlan
+  status:
+    ipClaimStatus:
+    - prefix: 10.0.0.3/24
+      gateway: 10.0.0.1
+    vlanClaimStatus:
+      vlanID: 100
+- apiVersion: workload.nephio.org/v1alpha1
+  kind: NFDeployment
+  metadata:
+    name: amf-cluster01
+    annotations:
+      specializer.nephio.org/debug: "true"
+  spec:
+    provider: amf.free5gc.io

--- a/krm-functions/nfdeploy-fn/fn/testdata/golden/nfdeployment_witthduplicatedependency/_expected.yaml
+++ b/krm-functions/nfdeploy-fn/fn/testdata/golden/nfdeployment_witthduplicatedependency/_expected.yaml
@@ -39,21 +39,20 @@ items:
       reason: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
       status: "True"
       type: req.nephio.org/v1alpha1.Interface.n2
-    - message: update for condition
-      status: "False"
+    - message: update done
+      status: "True"
       type: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
     - message: update condition for initial resource
       reason: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
       status: "True"
       type: req.nephio.org/v1alpha1.Dependency.upf
-    - message: not ready
-      reason: Specialize
-      status: "False"
-      type: nephio.org.Specializer.specialize
-    - message: create initial resource condition
+    - message: update condition for initial resource
       reason: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
-      status: "False"
+      status: "True"
       type: req.nephio.org/v1alpha1.Dependency.upf_duplicate
+    - reason: Ready
+      status: "True"
+      type: nephio.org.Specializer.specialize
 - apiVersion: req.nephio.org/v1alpha1
   kind: Capacity
   metadata:
@@ -137,3 +136,21 @@ items:
       specializer.nephio.org/debug: "true"
   spec:
     provider: amf.free5gc.io
+    interfaces:
+    - name: n2
+      ipv4:
+        address: 10.0.0.3/24
+        gateway: 10.0.0.1
+      vlanID: 100
+    networkInstances:
+    - name: vpc-ran
+      interfaces:
+      - n2
+    parametersRefs:
+    - name: amf-regional-upf-edge02
+      apiVersion: ref.nephio.org/v1alpha1
+      kind: Config
+    capacity:
+      maxDownlinkThroughput: "0"
+      maxSubscribers: 1000
+      maxUplinkThroughput: "0"

--- a/krm-functions/nfdeploy-fn/fn/testdata/golden/nfdeployment_witthduplicatedependency/capacity.yaml
+++ b/krm-functions/nfdeploy-fn/fn/testdata/golden/nfdeployment_witthduplicatedependency/capacity.yaml
@@ -1,0 +1,11 @@
+apiVersion: req.nephio.org/v1alpha1
+kind: Capacity
+metadata:
+  name: dataplane
+  annotations:
+    config.kubernetes.io/local-config: "true"
+    specializer.nephio.org/owner: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
+spec:
+  maxUplinkThroughput: 0
+  maxSubscribers: 1000
+  maxDownlinkThroughput: 0

--- a/krm-functions/nfdeploy-fn/fn/testdata/golden/nfdeployment_witthduplicatedependency/dependency.yaml
+++ b/krm-functions/nfdeploy-fn/fn/testdata/golden/nfdeployment_witthduplicatedependency/dependency.yaml
@@ -1,0 +1,18 @@
+apiVersion: req.nephio.org/v1alpha1
+kind: Dependency
+metadata:
+  name: upf
+  annotations:
+    specializer.nephio.org/owner: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
+    specializer.nephio.org/namespace: free5gc-cp
+spec:
+  packageName: free5gc-upf
+  injectors:
+    - apiVersion: workload.nephio.org/v1alpha1
+      kind: NFDeployment
+status:
+  injected:
+    - name: amf-regional-upf-edge02
+      namespace: free5gc-cp
+      apiVersion: ref.nephio.org/v1alpha1
+      kind: Config

--- a/krm-functions/nfdeploy-fn/fn/testdata/golden/nfdeployment_witthduplicatedependency/dependency_1.yaml
+++ b/krm-functions/nfdeploy-fn/fn/testdata/golden/nfdeployment_witthduplicatedependency/dependency_1.yaml
@@ -1,0 +1,18 @@
+apiVersion: req.nephio.org/v1alpha1
+kind: Dependency
+metadata:
+  name: upf_duplicate
+  annotations:
+    specializer.nephio.org/owner: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
+    specializer.nephio.org/namespace: free5gc-cp
+spec:
+  packageName: free5gc-upf
+  injectors:
+    - apiVersion: workload.nephio.org/v1alpha1
+      kind: NFDeployment
+status:
+  injected:
+    - name: amf-regional-upf-edge02
+      namespace: free5gc-cp
+      apiVersion: ref.nephio.org/v1alpha1
+      kind: Config

--- a/krm-functions/nfdeploy-fn/fn/testdata/golden/nfdeployment_witthduplicatedependency/dnn.yaml
+++ b/krm-functions/nfdeploy-fn/fn/testdata/golden/nfdeployment_witthduplicatedependency/dnn.yaml
@@ -1,0 +1,10 @@
+apiVersion: req.nephio.org/v1alpha1
+kind: DataNetwork
+metadata:
+  name: internet
+  annotations:
+    config.kubernetes.io/local-config: "true"
+    prefix: 10.0.0.0/8
+    specializer.nephio.org/owner: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
+spec:
+status: {}

--- a/krm-functions/nfdeploy-fn/fn/testdata/golden/nfdeployment_witthduplicatedependency/interface-n2.yaml
+++ b/krm-functions/nfdeploy-fn/fn/testdata/golden/nfdeployment_witthduplicatedependency/interface-n2.yaml
@@ -1,0 +1,18 @@
+apiVersion: req.nephio.org/v1alpha1
+kind: Interface
+metadata:
+  name: n2
+  annotations:
+    config.kubernetes.io/local-config: "true"
+    specializer.nephio.org/owner: workload.nephio.org/v1alpha1.NFDeployment.amf-cluster01
+spec:
+  networkInstance:
+    name: vpc-ran
+  cniType: sriov
+  attachmentType: vlan
+status:
+  ipClaimStatus:
+  - prefix: 10.0.0.3/24
+    gateway: 10.0.0.1
+  vlanClaimStatus:
+    vlanID: 100

--- a/krm-functions/nfdeploy-fn/fn/testdata/golden/nfdeployment_witthduplicatedependency/nfdeployment.yaml
+++ b/krm-functions/nfdeploy-fn/fn/testdata/golden/nfdeployment_witthduplicatedependency/nfdeployment.yaml
@@ -1,0 +1,8 @@
+apiVersion: workload.nephio.org/v1alpha1
+kind: NFDeployment
+metadata:
+  name: amf-cluster01
+  annotations:
+    specializer.nephio.org/debug: "true"
+spec:
+  provider: amf.free5gc.io

--- a/krm-functions/nfdeploy-fn/fn/testdata/golden/nfdeployment_witthduplicatedependency/workload_cluster.yaml
+++ b/krm-functions/nfdeploy-fn/fn/testdata/golden/nfdeployment_witthduplicatedependency/workload_cluster.yaml
@@ -1,0 +1,13 @@
+apiVersion: infra.nephio.org/v1alpha1
+kind: WorkloadCluster
+metadata:
+  name: cluster01
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  clusterName: cluster01
+  cnis:
+  - macvlan
+  - ipvlan
+  - sriov
+  masterInterface: eth1

--- a/krm-functions/pipeline-tests/pipeline_test.go
+++ b/krm-functions/pipeline-tests/pipeline_test.go
@@ -130,35 +130,6 @@ func TestPipelines(t *testing.T) {
 				nfFn,
 			},
 		},
-		{
-			inputDir:        "upf_pkg",
-			expectedDataDir: "real_deployment_2",
-			pipeline: []fn.ResourceListProcessorFunc{
-				nfFn,
-				nfFn,
-				if_fn.Run,
-				nad_fn.Run,
-				if_fn.Run,
-				dnn_fn.Run,
-				nfFn,
-
-				ipamFn.Run,
-
-				nad_fn.Run,
-				if_fn.Run,
-				dnn_fn.Run,
-				nfFn,
-
-				vlanFn.Run,
-
-				nad_fn.Run,
-				if_fn.Run,
-				dnn_fn.Run,
-				nfFn,
-				nfFn,
-				nfFn,
-			},
-		},
 	}
 
 	for _, tc := range tcs {

--- a/krm-functions/pipeline-tests/pipeline_test.go
+++ b/krm-functions/pipeline-tests/pipeline_test.go
@@ -130,6 +130,35 @@ func TestPipelines(t *testing.T) {
 				nfFn,
 			},
 		},
+		{
+			inputDir:        "upf_pkg",
+			expectedDataDir: "real_deployment_2",
+			pipeline: []fn.ResourceListProcessorFunc{
+				nfFn,
+				nfFn,
+				if_fn.Run,
+				nad_fn.Run,
+				if_fn.Run,
+				dnn_fn.Run,
+				nfFn,
+
+				ipamFn.Run,
+
+				nad_fn.Run,
+				if_fn.Run,
+				dnn_fn.Run,
+				nfFn,
+
+				vlanFn.Run,
+
+				nad_fn.Run,
+				if_fn.Run,
+				dnn_fn.Run,
+				nfFn,
+				nfFn,
+				nfFn,
+			},
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
These changes will ensure we have nf deploy fn to apply de dupulication logic to NF Deploy Param Ref

1. Changes to Add Dependency to check if it already exist before adding. Thanks @gvbalaji for the code snippet in chat.
2. Added test cases to handle dependency, if same file is present multiple times. Its not in our use case, but its better to add that too.
3. Added changes to pipeline tests to ensure, if I run the NF Deploy Fn multiples after that, it doesn't break the idempotency principle.


Docker image I used for testing - [docker.io/lostbrain/nfdeployfn:test-5](http://docker.io/lostbrain/nfdeployfn:test-5)