### PR TITLE
100% test-code-coverage for condition.go

### DIFF
--- a/controllers/pkg/porch/condition/condition_test.go
+++ b/controllers/pkg/porch/condition/condition_test.go
@@ -135,6 +135,20 @@ func TestPackageRevisionIsReady(t *testing.T) {
 			},
 			want: true,
 		},
+		"Condition type not present": {
+			conds: []porchv1alpha1.Condition{
+				{
+					Type:   "myterriblecondition",
+					Status: porchv1alpha1.ConditionStatus(porchv1alpha1.ConditionFalse),
+				},
+			},
+			readyGates: []porchv1alpha1.ReadinessGate{
+				{
+					ConditionType: "notmyterriblecondition",
+				},
+			},
+			want: false,
+		},
 		"Not ready": {
 			conds: []porchv1alpha1.Condition{
 				{


### PR DESCRIPTION
This change is to add 100% code coverage in Porch condition.go.