### PR TITLE
Upgrade Nephio to Go 1.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 .SHELLFLAGS = -ec
 
-GO_VERSION ?= 1.20.2
+GO_VERSION ?= 1.22.2
 IMG_REGISTRY ?= docker.io/nephio
 
 # find all subdirectories with a go.mod file in them

--- a/controllers/pkg/cluster/capi/capi.go
+++ b/controllers/pkg/cluster/capi/capi.go
@@ -61,7 +61,7 @@ func (r *Capi) isCapiClusterReady(ctx context.Context) bool {
 	r.l = log.FromContext(ctx)
 	name := r.GetClusterName()
 
-	cl := resource.GetUnstructuredFromGVK(&schema.GroupVersionKind{Group: capiv1beta1.GroupVersion.Group, Version: capiv1beta1.GroupVersion.Version, Kind: reflect.TypeOf(capiv1beta1.Cluster{}).Name()})
+	cl := resource.GetUnstructuredFromGVK(&schema.GroupVersionKind{Group: capiv1beta1.GroupVersion.Group, Version: capiv1beta1.GroupVersion.Version, Kind: reflect.TypeFor[capiv1beta1.Cluster]().Name()})
 	if err := r.Get(ctx, types.NamespacedName{Namespace: r.Secret.GetNamespace(), Name: name}, cl); err != nil {
 		r.l.Error(err, "cannot get cluster")
 		return false

--- a/controllers/pkg/go.mod
+++ b/controllers/pkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/nephio-project/nephio/controllers/pkg
 
-go 1.20
+go 1.22
 
 replace (
 	github.com/GoogleContainerTools/kpt/porch => github.com/GoogleContainerTools/kpt/porch v0.0.0-20230526213300-77a54e3b8e88

--- a/controllers/pkg/porch/util/packagevariant_test.go
+++ b/controllers/pkg/porch/util/packagevariant_test.go
@@ -18,14 +18,15 @@ package util
 
 import (
 	"context"
+	"reflect"
+	"testing"
+
 	porchapi "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
 	pvapi "github.com/GoogleContainerTools/kpt/porch/controllers/packagevariants/api/v1alpha1"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
-	"testing"
 )
 
 type fakeClient struct {
@@ -67,7 +68,7 @@ func TestPackageRevisionIsReady(t *testing.T) {
 						{
 							APIVersion: "config.porch.kpt.dev/v1alpha1",
 							Controller: &tr,
-							Kind:       reflect.TypeOf(pvapi.PackageVariant{}).Name(),
+							Kind:       reflect.TypeFor[pvapi.PackageVariant]().Name(),
 							Name:       "wc-argocd-argocd-cluster",
 						},
 					},

--- a/controllers/pkg/reconcilers/token/reconciler.go
+++ b/controllers/pkg/reconcilers/token/reconciler.go
@@ -185,7 +185,7 @@ func (r *reconciler) createToken(ctx context.Context, giteaClient giteaclient.Gi
 		secret := &corev1.Secret{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: corev1.SchemeGroupVersion.Identifier(),
-				Kind:       reflect.TypeOf(corev1.Secret{}).Name(),
+				Kind:       reflect.TypeFor[corev1.Secret]().Name(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:   cr.GetNamespace(),

--- a/default-go-lint.mk
+++ b/default-go-lint.mk
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 
-GOLANG_CI_VER ?= v1.57
+GOLANG_CI_VER ?= v1.52
 GIT_ROOT_DIR ?= $(dir $(lastword $(MAKEFILE_LIST)))
 include $(GIT_ROOT_DIR)/detect-container-runtime.mk
 

--- a/default-go-lint.mk
+++ b/default-go-lint.mk
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 
-GOLANG_CI_VER ?= v1.52
+GOLANG_CI_VER ?= v1.57
 GIT_ROOT_DIR ?= $(dir $(lastword $(MAKEFILE_LIST)))
 include $(GIT_ROOT_DIR)/detect-container-runtime.mk
 

--- a/default-go-test.mk
+++ b/default-go-test.mk
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 
-GO_VERSION ?= 1.20.2
+GO_VERSION ?= 1.22.2
 TEST_COVERAGE_FILE=lcov.info
 TEST_COVERAGE_HTML_FILE=coverage_unit.html
 TEST_COVERAGE_FUNC_FILE=func_coverage.out
@@ -28,7 +28,7 @@ unit: test
 .PHONY: test
 test: ## Run unit tests (go test)
 ifeq ($(CONTAINER_RUNNABLE), 0)
-		$(RUN_CONTAINER_COMMAND) docker.io/library/golang:${GO_VERSION}-alpine3.17 \
+		$(RUN_CONTAINER_COMMAND) docker.io/library/golang:${GO_VERSION}-alpine3.19 \
          sh -e -c "go test ./... -v -coverprofile ${TEST_COVERAGE_FILE}; \
          go tool cover -html=${TEST_COVERAGE_FILE} -o ${TEST_COVERAGE_HTML_FILE}; \
          go tool cover -func=${TEST_COVERAGE_FILE} -o ${TEST_COVERAGE_FUNC_FILE}"

--- a/krm-functions/configinject-fn/Dockerfile
+++ b/krm-functions/configinject-fn/Dockerfile
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-FROM golang:1.20-alpine
+FROM golang:1.22-alpine
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 COPY krm-functions/ krm-functions/

--- a/krm-functions/configinject-fn/fn/function.go
+++ b/krm-functions/configinject-fn/fn/function.go
@@ -63,7 +63,7 @@ func New(c client.Client) *FnR {
 		Owns: map[corev1.ObjectReference]condkptsdk.ResourceKind{
 			{
 				APIVersion: nephiorefv1alpha1.GroupVersion.Identifier(),
-				Kind:       reflect.TypeOf(nephiorefv1alpha1.Config{}).Name(),
+				Kind:       reflect.TypeFor[nephiorefv1alpha1.Config]().Name(),
 			}: condkptsdk.ChildLocal,
 		},
 		Watch: map[corev1.ObjectReference]condkptsdk.WatchCallbackFn{

--- a/krm-functions/configinject-fn/go.mod
+++ b/krm-functions/configinject-fn/go.mod
@@ -1,6 +1,6 @@
 module github.com/nephio-project/nephio/krm-functions/configinject-fn
 
-go 1.20
+go 1.22
 
 replace github.com/nephio-project/nephio/krm-functions/lib => ../lib
 

--- a/krm-functions/dnn-fn/Dockerfile
+++ b/krm-functions/dnn-fn/Dockerfile
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-FROM golang:1.20-alpine
+FROM golang:1.22-alpine
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 COPY krm-functions/ krm-functions/

--- a/krm-functions/dnn-fn/fn/function.go
+++ b/krm-functions/dnn-fn/fn/function.go
@@ -69,7 +69,7 @@ func Run(rl *fn.ResourceList) (bool, error) {
 			Watch: map[corev1.ObjectReference]condkptsdk.WatchCallbackFn{
 				{
 					APIVersion: infrav1alpha1.GroupVersion.Identifier(),
-					Kind:       reflect.TypeOf(infrav1alpha1.WorkloadCluster{}).Name(),
+					Kind:       reflect.TypeFor[infrav1alpha1.WorkloadCluster]().Name(),
 				}: myFn.WorkloadClusterCallbackFn,
 			},
 			PopulateOwnResourcesFn: myFn.desiredOwnedResourceList,

--- a/krm-functions/dnn-fn/go.mod
+++ b/krm-functions/dnn-fn/go.mod
@@ -1,6 +1,6 @@
 module github.com/nephio-project/nephio/krm-functions/dnn-fn
 
-go 1.20
+go 1.22
 
 replace github.com/nephio-project/nephio/krm-functions/lib => ../lib
 

--- a/krm-functions/gen-configmap-fn/Dockerfile
+++ b/krm-functions/gen-configmap-fn/Dockerfile
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-FROM golang:1.20-alpine
+FROM golang:1.22-alpine
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 COPY krm-functions/ krm-functions/

--- a/krm-functions/gen-configmap-fn/go.mod
+++ b/krm-functions/gen-configmap-fn/go.mod
@@ -1,6 +1,6 @@
 module github.com/nephio-project/nephio/krm-functions/gen-configmap-fn
 
-go 1.20
+go 1.22
 
 replace github.com/nephio-project/nephio/krm-functions/lib => ../lib
 

--- a/krm-functions/interface-fn/Dockerfile
+++ b/krm-functions/interface-fn/Dockerfile
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-FROM golang:1.20-alpine
+FROM golang:1.22-alpine
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 COPY krm-functions/ krm-functions/

--- a/krm-functions/interface-fn/fn/function.go
+++ b/krm-functions/interface-fn/fn/function.go
@@ -56,7 +56,7 @@ func Run(rl *fn.ResourceList) (bool, error) {
 			Owns: map[corev1.ObjectReference]condkptsdk.ResourceKind{
 				{
 					APIVersion: nadv1.SchemeGroupVersion.Identifier(),
-					Kind:       reflect.TypeOf(nadv1.NetworkAttachmentDefinition{}).Name(),
+					Kind:       reflect.TypeFor[nadv1.NetworkAttachmentDefinition]().Name(),
 				}: condkptsdk.ChildRemoteCondition,
 				{
 					APIVersion: ipamv1alpha1.GroupVersion.Identifier(),
@@ -70,7 +70,7 @@ func Run(rl *fn.ResourceList) (bool, error) {
 			Watch: map[corev1.ObjectReference]condkptsdk.WatchCallbackFn{
 				{
 					APIVersion: infrav1alpha1.GroupVersion.Identifier(),
-					Kind:       reflect.TypeOf(infrav1alpha1.WorkloadCluster{}).Name(),
+					Kind:       reflect.TypeFor[infrav1alpha1.WorkloadCluster]().Name(),
 				}: myFn.WorkloadClusterCallbackFn,
 			},
 			PopulateOwnResourcesFn: myFn.desiredOwnedResourceList,
@@ -289,7 +289,7 @@ func BuildNetworkAttachmentDefinition(meta metav1.ObjectMeta, spec nadv1.Network
 	return &nadv1.NetworkAttachmentDefinition{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: nadv1.SchemeGroupVersion.Identifier(),
-			Kind:       reflect.TypeOf(nadv1.NetworkAttachmentDefinition{}).Name(),
+			Kind:       reflect.TypeFor[nadv1.NetworkAttachmentDefinition]().Name(),
 		},
 		ObjectMeta: meta,
 		Spec:       spec,

--- a/krm-functions/interface-fn/go.mod
+++ b/krm-functions/interface-fn/go.mod
@@ -1,6 +1,6 @@
 module github.com/nephio-project/nephio/krm-functions/interface-fn
 
-go 1.20
+go 1.22
 
 replace github.com/nephio-project/nephio/krm-functions/lib => ../lib
 

--- a/krm-functions/ipam-fn/Dockerfile
+++ b/krm-functions/ipam-fn/Dockerfile
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-FROM golang:1.20-alpine
+FROM golang:1.22-alpine
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 COPY krm-functions/ krm-functions/

--- a/krm-functions/ipam-fn/go.mod
+++ b/krm-functions/ipam-fn/go.mod
@@ -1,6 +1,6 @@
 module github.com/nephio-project/nephio/krm-functions/ipam-fn
 
-go 1.20
+go 1.22
 
 replace github.com/nephio-project/nephio/krm-functions/lib => ../lib
 

--- a/krm-functions/lib/condkptsdk/sdk_stage1_update_children.go
+++ b/krm-functions/lib/condkptsdk/sdk_stage1_update_children.go
@@ -133,6 +133,7 @@ func (r *sdk) updateChildren() {
 		for _, obj := range diff.createObjs {
 			if r.debug {
 				fn.Logf("stage1: diff action -> create obj: ref: %s, ownkind: %s\n", kptfilelibv1.GetConditionType(&obj.ref), obj.ownKind)
+				// #nosec G601
 			}
 			status := kptv1.ConditionFalse
 			if obj.ownKind == ChildLocal {
@@ -151,6 +152,7 @@ func (r *sdk) updateChildren() {
 		for _, obj := range diff.updateObjs {
 			if r.debug {
 				fn.Logf("stage1: diff action -> update obj: %s\n", kptfilelibv1.GetConditionType(&obj.ref))
+				// #nosec G601
 			}
 			if err := r.upsertChildObject(ownGVKKind, []corev1.ObjectReference{forRef, obj.ref}, obj, nil, "update resource", kptv1.ConditionFalse, false); err != nil {
 				// the errors are already logged, we set the result in the for condition
@@ -163,6 +165,7 @@ func (r *sdk) updateChildren() {
 		for _, obj := range diff.deleteObjs {
 			if r.debug {
 				fn.Logf("stage1: diff action -> delete obj: %s\n", kptfilelibv1.GetConditionType(&obj.ref))
+				// #nosec G601
 			}
 			if err := r.deleteChildObject(ownGVKKind, []corev1.ObjectReference{forRef, obj.ref}, obj, "delete resource"); err != nil {
 				// the errors are already logged, we set the result in the for condition

--- a/krm-functions/lib/go.mod
+++ b/krm-functions/lib/go.mod
@@ -1,6 +1,6 @@
 module github.com/nephio-project/nephio/krm-functions/lib
 
-go 1.20
+go 1.22
 
 require (
 	github.com/GoogleContainerTools/kpt v1.0.0-beta.29.0.20230327202912-01513604feaa

--- a/krm-functions/lib/kubeobject/kubeobject.go
+++ b/krm-functions/lib/kubeobject/kubeobject.go
@@ -158,8 +158,7 @@ func (o *KubeObjectExt[T1]) getFieldOrPanic(value *T1, fieldName string) interfa
 }
 
 func validateTypeOrPanic[T1 any]() {
-	var x T1
-	v := reflect.TypeOf(x)
+	v := reflect.TypeFor[T1]()
 	if v.Kind() != reflect.Struct {
 		panic(fmt.Sprintf("type %q is not a struct", v.Name()))
 	}

--- a/krm-functions/lib/kubeobject/lists.go
+++ b/krm-functions/lib/kubeobject/lists.go
@@ -83,8 +83,7 @@ func GetSingleton[T any, PT PtrIsRuntimeObject[T]](objs fn.KubeObjects) (*T, err
 		return nil, err
 	}
 	if len(typedObjs) != 1 {
-		var x T
-		return nil, fmt.Errorf("expected exactly 1 instance of %v in the kpt package, but got %v", reflect.TypeOf(x).Name(), len(typedObjs))
+		return nil, fmt.Errorf("expected exactly 1 instance of %v in the kpt package, but got %v", reflect.TypeFor[T]().Name(), len(typedObjs))
 	}
 	return typedObjs[0], nil
 }

--- a/krm-functions/lib/nad/v1/nad_test.go
+++ b/krm-functions/lib/nad/v1/nad_test.go
@@ -17,14 +17,15 @@ limitations under the License.
 package v1
 
 import (
+	"reflect"
+	"testing"
+
 	"github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
 	"github.com/google/go-cmp/cmp"
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
 	"sigs.k8s.io/yaml"
-	"testing"
 )
 
 var nadTestSriov = `apiVersion: "k8s.cni.cncf.io/v1"
@@ -105,7 +106,7 @@ func TestNewFromGoStruct(t *testing.T) {
 			input: &nadv1.NetworkAttachmentDefinition{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: nadv1.SchemeGroupVersion.Identifier(),
-					Kind:       reflect.TypeOf(nadv1.NetworkAttachmentDefinition{}).Name(),
+					Kind:       reflect.TypeFor[nadv1.NetworkAttachmentDefinition]().Name(),
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "a",

--- a/krm-functions/nad-fn/Dockerfile
+++ b/krm-functions/nad-fn/Dockerfile
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-FROM golang:1.20-alpine
+FROM golang:1.22-alpine
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 COPY krm-functions/ krm-functions/

--- a/krm-functions/nad-fn/fn/function.go
+++ b/krm-functions/nad-fn/fn/function.go
@@ -55,7 +55,7 @@ func Run(rl *fn.ResourceList) (bool, error) {
 		&condkptsdk.Config{
 			For: corev1.ObjectReference{
 				APIVersion: nadv1.SchemeGroupVersion.Identifier(),
-				Kind:       reflect.TypeOf(nadv1.NetworkAttachmentDefinition{}).Name(),
+				Kind:       reflect.TypeFor[nadv1.NetworkAttachmentDefinition]().Name(),
 			},
 			Watch: map[corev1.ObjectReference]condkptsdk.WatchCallbackFn{
 				{
@@ -168,7 +168,7 @@ func (f *nadFn) updateResourceFn(_ *fn.KubeObject, objs fn.KubeObjects) (fn.Kube
 	nad, err := nadlibv1.NewFromGoStruct(&nadv1.NetworkAttachmentDefinition{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: nadv1.SchemeGroupVersion.Identifier(),
-			Kind:       reflect.TypeOf(nadv1.NetworkAttachmentDefinition{}).Name(),
+			Kind:       reflect.TypeFor[nadv1.NetworkAttachmentDefinition]().Name(),
 		},
 		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s", f.forName, interfaceObjs[0].GetName()), Namespace: f.forNamespace},
 	})

--- a/krm-functions/nad-fn/go.mod
+++ b/krm-functions/nad-fn/go.mod
@@ -1,6 +1,6 @@
 module github.com/nephio-project/nephio/krm-functions/nad-fn
 
-go 1.20
+go 1.22
 
 replace github.com/nephio-project/nephio/krm-functions/lib => ../lib
 

--- a/krm-functions/nfdeploy-fn/Dockerfile
+++ b/krm-functions/nfdeploy-fn/Dockerfile
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-FROM golang:1.20-alpine
+FROM golang:1.22-alpine
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 COPY krm-functions/ krm-functions/

--- a/krm-functions/nfdeploy-fn/fn/function.go
+++ b/krm-functions/nfdeploy-fn/fn/function.go
@@ -74,7 +74,7 @@ func Run(rl *fn.ResourceList) (bool, error) {
 			Watch: map[corev1.ObjectReference]condkptsdk.WatchCallbackFn{
 				{
 					APIVersion: infrav1alpha1.GroupVersion.Identifier(),
-					Kind:       reflect.TypeOf(infrav1alpha1.WorkloadCluster{}).Name(),
+					Kind:       reflect.TypeFor[infrav1alpha1.WorkloadCluster]().Name(),
 				}: nfDeployFn.WorkloadClusterCallbackFn,
 			},
 			PopulateOwnResourcesFn: nfDeployFn.desiredOwnedResourceList,

--- a/krm-functions/nfdeploy-fn/go.mod
+++ b/krm-functions/nfdeploy-fn/go.mod
@@ -1,6 +1,6 @@
 module github.com/nephio-project/nephio/krm-functions/nfdeploy-fn
 
-go 1.20
+go 1.22
 
 replace github.com/nephio-project/nephio/krm-functions/lib => ../lib
 

--- a/krm-functions/pipeline-tests/go.mod
+++ b/krm-functions/pipeline-tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/nephio-project/nephio/krm-functions/pipeline-tests
 
-go 1.20
+go 1.22
 
 // always test the latest versions of all functions/libs
 replace (

--- a/krm-functions/ueransim-deploy-fn/Dockerfile
+++ b/krm-functions/ueransim-deploy-fn/Dockerfile
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-FROM golang:1.20-alpine
+FROM golang:1.22-alpine
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 COPY krm-functions/ krm-functions/

--- a/krm-functions/ueransim-deploy-fn/fn/function.go
+++ b/krm-functions/ueransim-deploy-fn/fn/function.go
@@ -48,7 +48,7 @@ func Run(rl *fn.ResourceList) (bool, error) {
 		&condkptsdk.Config{
 			For: corev1.ObjectReference{
 				APIVersion: appsv1.SchemeGroupVersion.Identifier(),
-				Kind:       reflect.TypeOf(appsv1.Deployment{}).Name(),
+				Kind:       reflect.TypeFor[appsv1.Deployment]().Name(),
 			},
 			Owns: map[corev1.ObjectReference]condkptsdk.ResourceKind{
 				{
@@ -61,17 +61,17 @@ func Run(rl *fn.ResourceList) (bool, error) {
 				}: condkptsdk.ChildInitial,
 				{
 					APIVersion: corev1.SchemeGroupVersion.Identifier(),
-					Kind:       reflect.TypeOf(corev1.ConfigMap{}).Name(),
+					Kind:       reflect.TypeFor[corev1.ConfigMap]().Name(),
 				}: condkptsdk.ChildLocal,
 				{
 					APIVersion: corev1.SchemeGroupVersion.Identifier(),
-					Kind:       reflect.TypeOf(corev1.Service{}).Name(),
+					Kind:       reflect.TypeFor[corev1.Service]().Name(),
 				}: condkptsdk.ChildLocal,
 			},
 			Watch: map[corev1.ObjectReference]condkptsdk.WatchCallbackFn{
 				{
 					APIVersion: infrav1alpha1.GroupVersion.Identifier(),
-					Kind:       reflect.TypeOf(infrav1alpha1.WorkloadCluster{}).Name(),
+					Kind:       reflect.TypeFor[infrav1alpha1.WorkloadCluster]().Name(),
 				}: myFn.WorkloadClusterCallbackFn,
 			},
 			PopulateOwnResourcesFn: myFn.desiredOwnedResourceList,
@@ -324,7 +324,7 @@ func buildConfigMapKubeObject(meta metav1.ObjectMeta, key, value string) (*fn.Ku
 	o := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: corev1.SchemeGroupVersion.Identifier(),
-			Kind:       reflect.TypeOf(corev1.ConfigMap{}).Name(),
+			Kind:       reflect.TypeFor[corev1.ConfigMap]().Name(),
 		},
 		ObjectMeta: meta,
 		Data: map[string]string{
@@ -339,7 +339,7 @@ func buildServiceKubeObject(meta metav1.ObjectMeta, spec corev1.ServiceSpec) (*f
 	o := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: corev1.SchemeGroupVersion.Identifier(),
-			Kind:       reflect.TypeOf(corev1.Service{}).Name(),
+			Kind:       reflect.TypeFor[corev1.Service]().Name(),
 		},
 		ObjectMeta: meta,
 		Spec:       spec,

--- a/krm-functions/ueransim-deploy-fn/go.mod
+++ b/krm-functions/ueransim-deploy-fn/go.mod
@@ -1,6 +1,6 @@
 module github.com/nephio-project/nephio/krm-functions/ueransim-deploy-fn
 
-go 1.20
+go 1.22
 
 replace github.com/nephio-project/nephio/krm-functions/lib => ../lib
 

--- a/krm-functions/vlan-fn/Dockerfile
+++ b/krm-functions/vlan-fn/Dockerfile
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-FROM golang:1.20-alpine
+FROM golang:1.22-alpine
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 COPY krm-functions/ krm-functions/

--- a/krm-functions/vlan-fn/go.mod
+++ b/krm-functions/vlan-fn/go.mod
@@ -1,6 +1,6 @@
 module github.com/nephio-project/nephio/krm-functions/vlan-fn
 
-go 1.20
+go 1.22
 
 replace github.com/nephio-project/nephio/krm-functions/lib => ../lib
 

--- a/operators/nephio-controller-manager/Dockerfile
+++ b/operators/nephio-controller-manager/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM golang:1.22 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/operators/nephio-controller-manager/go.mod
+++ b/operators/nephio-controller-manager/go.mod
@@ -1,6 +1,6 @@
 module github.com/nephio-project/nephio/operators/nephio-controller-manager
 
-go 1.20
+go 1.22
 
 replace (
 	github.com/GoogleContainerTools/kpt/porch => github.com/GoogleContainerTools/kpt/porch v0.0.0-20230526213300-77a54e3b8e88

--- a/testing/mockeryutils/go.mod
+++ b/testing/mockeryutils/go.mod
@@ -1,6 +1,6 @@
 module github.com/nephio-project/nephio/testing/mockeryutils
 
-go 1.20
+go 1.22
 
 require github.com/stretchr/testify v1.8.4
 


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment only one  /kind <> line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>  /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it:**

- Updated go version in go.mod files
- Updated go version in github workflows
- Updated base image to 1.22.2-bookworm in Dockerfiles
- Updated Go/Golang-CI/GoSec versions in makefiles
- Updated reflect.TypeOf() to reflect.TypeFor[]() where relevant

**Which issue(s) this PR fixes:**
Fixes [Issue 510](https://github.com/nephio-project/nephio/issues/510).

**Special notes for your reviewer:**

**Does this PR introduce a user-facing change?:**
no
