### PR TITLE
Bumping gotests image version to next build

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -4,7 +4,7 @@ presubmits:
     run_if_changed: "(\\.go|Makefile)$"
     spec:
       containers:
-      - image: nephio/gotests:1782782171367346176
+      - image: nephio/gotests:1783899289886396416
         command:
         - make
         args:
@@ -14,7 +14,7 @@ presubmits:
     run_if_changed: "(\\.go|Makefile)$"
     spec:
       containers:
-      - image: nephio/gotests:1782782171367346176
+      - image: nephio/gotests:1783899289886396416
         command:
         - make
         args:
@@ -24,7 +24,7 @@ presubmits:
     run_if_changed: "(\\.go|Makefile)$"
     spec:
       containers:
-      - image: nephio/gotests:1782782171367346176
+      - image: nephio/gotests:1783899289886396416
         command:
         - make
         args:
@@ -34,7 +34,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: nephio/gotests:1782782171367346176
+      - image: nephio/gotests:1783899289886396416
         command:
         - "/bin/sh"
         - "-c"
@@ -74,7 +74,7 @@ presubmits:
     run_if_changed: "^.*.go$"
     spec:
       containers:
-      - image: nephio/gotests:1782782171367346176
+      - image: nephio/gotests:1783899289886396416
         command:
         - "/usr/local/bin/lichen.sh"
 


### PR DESCRIPTION
golangci-lint update to work with go 1.22 updated other components as well
This resolves failing tests in https://github.com/nephio-project/nephio/pull/597 and https://github.com/nephio-project/nephio/pull/722