### PR TITLE
Modernizing golangci-lint configuration for latest version syntax

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,11 @@
 run:
-  skip-dirs:
-    - vendor
+  timeout: 10m
 
-  skip-files:
+issues:
+  exclude-dirs:
+    - "vendor"
+
+  exclude-files:
     - ".*\\_test.go$"
 
 linters:

--- a/default-go-lint.mk
+++ b/default-go-lint.mk
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 
-GOLANG_CI_VER ?= v1.52
+GOLANG_CI_VER ?= v1.57
 GIT_ROOT_DIR ?= $(dir $(lastword $(MAKEFILE_LIST)))
 include $(GIT_ROOT_DIR)/detect-container-runtime.mk
 
@@ -22,7 +22,7 @@ include $(GIT_ROOT_DIR)/detect-container-runtime.mk
 lint: ## Run Go linter against the codebase
 ifeq ($(CONTAINER_RUNNABLE), 0)
 	$(RUN_CONTAINER_COMMAND) docker.io/golangci/golangci-lint:${GOLANG_CI_VER}-alpine \
-	 golangci-lint run ./... -v --timeout 10m
+	 golangci-lint run ./... -v
 else
-	golangci-lint run ./... -v --timeout 10m
+	golangci-lint run ./... -v
 endif


### PR DESCRIPTION
Golangci-lint config syntax has changed in recent version, this removes warning messages from logs:
```
level=warning msg="[config_reader] The configuration option `run.skip-files` is deprecated, please use `issues.exclude-files`."
level=warning msg="[config_reader] The configuration option `run.skip-dirs` is deprecated, please use `issues.exclude-dirs`."
```
Timeout is now config defined not command-line switch