### PR TITLE
SBOM and license scanning information and monitor fixes

### DIFF
--- a/.clomonitor.yml
+++ b/.clomonitor.yml
@@ -1,0 +1,19 @@
+# CLOMonitor metadata file
+
+# Checks exemptions
+exemptions:
+  - check: artifacthub_badge
+    reason: "Nephio artifacts are hosted on DockerHub" 
+
+  - check: signed_releases
+    reason: >
+      "All Nephio release images are cryptographically signed during build with cosign. 
+      Images and signatures are hosted in DockerHub. Naming convention is that signature 
+      filename is an image sha256 digest and the file extension is .sig
+      Scorecard check is currently limited to repositories hosted on GitHub,
+      and does not support other source hosting repositories."
+
+licenseScanning:
+  # In Nephio every PR is being tested for license compliance. Those include Fossology scan, Scancode-toolkit scan and 
+  # Lichen scan of produced binaries. The results of those scans are available at Prow site:
+  url: https://prow.nephio.io/

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you wish to participate in building Nephio, please join our SIG meetings, or 
 project boards.
 
 ## Software Bill Of Materials
-Release container images are digitally signed as well as have Software Bill Of Materials (SBOM) created for them. Both signature and sbom are stored in [DockerHub]([https://hub.docker.com/ ](https://hub.docker.com/u/nephio) as artifacts. 
+Release container images are digitally signed as well as have Software Bill Of Materials (SBOM) created for them. Both signature and sbom are stored in [DockerHub](https://hub.docker.com/u/nephio) as artifacts. 
 Naming convention is that filename is an image sha256 digest and the file extension is respectively .sig and .sbom
 
 ## Community

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ series and it's corresponding  [wiki pages](https://wiki.nephio.org/display/HOME
 If you wish to participate in building Nephio, please join our SIG meetings, or reach out to us on Slack. You may also want to peruse the [Nephio Planning](https://github.com/orgs/nephio-project/projects)
 project boards.
 
+## Software Bill Of Materials
+Release container images are digitally signed as well as have Software Bill Of Materials (SBOM) created for them. Both signature and sbom are stored in [DockerHub]([https://hub.docker.com/ ](https://hub.docker.com/u/nephio) as artifacts. 
+Naming convention is that filename is an image sha256 digest and the file extension is respectively .sig and .sbom
+
 ## Community
 
 Please see the following resources for more information:


### PR DESCRIPTION
This PR adds SBOM information to README as well as [CLOMonitor](https://github.com/cncf/clomonitor) exemption configuration. This resolves https://github.com/nephio-project/nephio/issues/551 and https://github.com/nephio-project/nephio/issues/546