### PR TITLE
Improve approval reconciler timings

### DIFF
--- a/controllers/pkg/reconcilers/config/config.go
+++ b/controllers/pkg/reconcilers/config/config.go
@@ -28,11 +28,12 @@ import (
 )
 
 type ControllerConfig struct {
-	PorchClient     client.Client
-	PorchRESTClient rest.Interface
-	Poll            time.Duration
-	Copts           controller.Options
-	Address         string // backend server address
-	IpamClientProxy clientproxy.Proxy[*ipamv1alpha1.NetworkInstance, *ipamv1alpha1.IPClaim]
-	VlanClientProxy clientproxy.Proxy[*vlanv1alpha1.VLANIndex, *vlanv1alpha1.VLANClaim]
+	PorchClient     		client.Client
+	PorchRESTClient 		rest.Interface
+	Poll            		time.Duration
+	Copts           		controller.Options
+	Address         		string // backend server address
+	IpamClientProxy 		clientproxy.Proxy[*ipamv1alpha1.NetworkInstance, *ipamv1alpha1.IPClaim]
+	VlanClientProxy 		clientproxy.Proxy[*vlanv1alpha1.VLANIndex, *vlanv1alpha1.VLANClaim]
+	ApprovalRequeueDuration	int64
 }

--- a/controllers/pkg/reconcilers/config/config.go
+++ b/controllers/pkg/reconcilers/config/config.go
@@ -28,12 +28,12 @@ import (
 )
 
 type ControllerConfig struct {
-	PorchClient     		client.Client
-	PorchRESTClient 		rest.Interface
-	Poll            		time.Duration
-	Copts           		controller.Options
-	Address         		string // backend server address
-	IpamClientProxy 		clientproxy.Proxy[*ipamv1alpha1.NetworkInstance, *ipamv1alpha1.IPClaim]
-	VlanClientProxy 		clientproxy.Proxy[*vlanv1alpha1.VLANIndex, *vlanv1alpha1.VLANClaim]
-	ApprovalRequeueDuration	int64
+	PorchClient             client.Client
+	PorchRESTClient         rest.Interface
+	Poll                    time.Duration
+	Copts                   controller.Options
+	Address                 string // backend server address
+	IpamClientProxy         clientproxy.Proxy[*ipamv1alpha1.NetworkInstance, *ipamv1alpha1.IPClaim]
+	VlanClientProxy         clientproxy.Proxy[*vlanv1alpha1.VLANIndex, *vlanv1alpha1.VLANClaim]
+	ApprovalRequeueDuration int64
 }

--- a/operators/nephio-controller-manager/main.go
+++ b/operators/nephio-controller-manager/main.go
@@ -65,6 +65,7 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var enabledReconcilersString string
+	var approvalRequeueDuration int64
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -72,6 +73,7 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&enabledReconcilersString, "reconcilers", "", "reconcilers that should be enabled; use * to mean 'enable all'")
+	flag.Int64Var(&approvalRequeueDuration, "approval-requeue-duration", 15, "Interval to allow before requeue of the approval controller reconcile key")
 
 	opts := zap.Options{
 		Development: true,
@@ -139,6 +141,7 @@ func main() {
 		VlanClientProxy: vlan.New(ctx, clientproxy.Config{
 			Address: backendAddress,
 		}),
+		ApprovalRequeueDuration: approvalRequeueDuration,
 	}
 
 	enabledReconcilers := parseReconcilers(enabledReconcilersString)


### PR DESCRIPTION
Change approval controller PR Get to hit the api directly instead of reading from local cache.
Adjust the reque duration to prevent race condition.

During debugging the approval delay issue reported [here](https://github.com/nephio-project/nephio/issues/462) it became apparent that the packagerev being fetched was a cached version which didn't get updated for quite some time.
To circumvent this, we are retrieving the PR using the apiReader interface which bypasses the local cache and hits the k8s api directly.
