### PR TITLE
updates the dockerfile to run kopf as nonroot

### DIFF
--- a/operators/o2ims-operator/Dockerfile
+++ b/operators/o2ims-operator/Dockerfile
@@ -15,13 +15,28 @@
 ##########################################################################
 
 FROM python:3.12.9-alpine3.21 AS builder
-COPY controllers/ /src/
-COPY requirements.txt /
-RUN pip install --user -r /requirements.txt --no-cache-dir
-############### Target
-FROM python:3.12.9-alpine3.21 AS target
-COPY --from=builder /root/.local \
-                   /src/ \
-                  /root/.local
-ENV PATH=/root/.local/bin:$PATH
-CMD ["kopf", "run", "/root/.local/manager.py", "--all-namespaces"]
+
+# Create a non-root user
+RUN addgroup --gid 65535 o2ims && \
+    adduser --uid 65535 --disabled-password --home /home/o2ims -G o2ims o2ims
+
+# Set working directory
+WORKDIR /usr/o2ims
+
+# Copy application files
+COPY --chown=o2ims:o2ims controllers/ src/
+COPY --chown=o2ims:o2ims requirements.txt requirements.txt
+
+# Switch to non-root user
+USER o2ims
+
+# Create a virtual environment and install dependencies
+RUN python -m venv /home/o2ims/venv && \
+    /home/o2ims/venv/bin/pip install --no-cache-dir -r requirements.txt
+
+# Set environment variables
+ENV PATH="/home/o2ims/venv/bin:${PATH}" \
+    VIRTUAL_ENV="/home/o2ims/venv"
+
+# Run the application
+CMD ["kopf", "run", "/usr/o2ims/src/manager.py", "--all-namespaces"]

--- a/operators/o2ims-operator/README.md
+++ b/operators/o2ims-operator/README.md
@@ -73,13 +73,13 @@ nohup kubectl proxy --port 8080 &>/dev/null &
 Build a Docker image: 
 
 ```bash
-docker build -t o2ims:latest -f Dockerfile .
+docker build -t o2ims-operator:latest -f Dockerfile .
 ```
 
 Push this image in your cluster, here we are using a `kind` cluster so we will push using the below command:
 
 ```bash
-kind load docker-image o2ims:latest -n o2ims-mgmt
+kind load docker-image o2ims-operator:latest -n o2ims-mgmt
 ```
 
 `NOTE`: `o2ims-mgmt` is the name of the kind cluster. It is good to mention cluster name if you have multiple clusters.


### PR DESCRIPTION
This PR updates the Dockerfile to run `kopf` as non-root. It also updates the README to reflect the correct container image being used.