### PR TITLE
Update o2ims operator for integer revisions

### DIFF
--- a/operators/o2ims-operator/controllers/utils.py
+++ b/operators/o2ims-operator/controllers/utils.py
@@ -79,7 +79,7 @@ def create_package_variant(
                 "upstream": {
                     "repo": f"{pv_param['repo_location']}",
                     "package": f"{pv_param['template_name']}",
-                    "revision": f"{pv_param['template_version']}",
+                    "revision": int(f"{pv_param['template_version']}"),
                 },
                 "downstream": {
                     # TODO: should the repo be configurable instead of being hardcoded?

--- a/operators/o2ims-operator/controllers/utils.py
+++ b/operators/o2ims-operator/controllers/utils.py
@@ -79,7 +79,7 @@ def create_package_variant(
                 "upstream": {
                     "repo": f"{pv_param['repo_location']}",
                     "package": f"{pv_param['template_name']}",
-                    "revision": int(f"{pv_param['template_version']}"),
+                    "workspaceName": f"{pv_param['template_version']}",
                 },
                 "downstream": {
                     # TODO: should the repo be configurable instead of being hardcoded?


### PR DESCRIPTION
Update the o2ims operator so that it requests creation of PackageVariants of upstream packages with integer rather than string revisions.

This change has been tested locally and with this change, the o2ims tests will run correctly.