### PR TITLE
Fix generic specializer infinite loop

### DIFF
--- a/controllers/pkg/reconcilers/generic-specializer/reconciler.go
+++ b/controllers/pkg/reconcilers/generic-specializer/reconciler.go
@@ -286,6 +286,11 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 						log.Info("generic specializer conditions", "packageName", pr.Spec.PackageName, "repository", pr.Spec.RepositoryName, "status", c.Status, "condition", c.Type, "message", c.Message)
 					}
 				}
+
+				if porchv1alpha1.PackageRevisionIsReady(pr.Spec.ReadinessGates, porchcondition.GetPorchConditions(kptfile.Status.Conditions)) {
+					r.recorder.Eventf(pr, corev1.EventTypeNormal, "PackageRevision is Ready", "readiness gates met for %s, in repo %s", pr.Spec.PackageName, pr.Spec.RepositoryName)
+					return ctrl.Result{}, nil
+				}
 			}
 		}
 


### PR DESCRIPTION
As part of the free5gc test 008, we copy, pull, mutate, push a UPF pkg.
https://github.com/nephio-project/test-infra/blob/main/e2e/tests/free5gc/008.sh#L53

The push fails due to the generic specializer continuously trying to update the claims on the relevant resources.

The reconciler itself needs to be reworked properly to address the issue and determine when it is "finished"
For now, this is a quick fix to get the test suite passing.