### PR TITLE
Bump Golang base image version to 1.24.3

### DIFF
--- a/gitops-tools/kpt-argocd-cmp/kpt-render/Dockerfile
+++ b/gitops-tools/kpt-argocd-cmp/kpt-render/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=golang:1.23.8@sha256:ec5612bbd9e96d5b80a8b968cea06a4a9b985fe200ff6da784bf607063273c59
+ARG BUILDER_IMAGE=golang:1.24.3@sha256:81bf5927dc91aefb42e2bc3a5abdbe9bb3bae8ba8b107e2a4cf43ce3402534c6
 ARG BASE_IMAGE=quay.io/argoproj/argocd:v3.0.6
 
 FROM --platform=$BUILDPLATFORM ${BUILDER_IMAGE} AS build

--- a/gitops-tools/kpt-argocd-cmp/kpt-repo/Dockerfile
+++ b/gitops-tools/kpt-argocd-cmp/kpt-repo/Dockerfile
@@ -1,5 +1,5 @@
 # Build
-ARG BUILDER_IMAGE=golang:1.23.8@sha256:ec5612bbd9e96d5b80a8b968cea06a4a9b985fe200ff6da784bf607063273c59
+ARG BUILDER_IMAGE=golang:1.24.3@sha256:81bf5927dc91aefb42e2bc3a5abdbe9bb3bae8ba8b107e2a4cf43ce3402534c6
 ARG BASE_IMAGE=quay.io/argoproj/argocd:v3.0.6
 
 FROM --platform=$BUILDPLATFORM ${BUILDER_IMAGE} AS build

--- a/krm-functions/configinject-fn/Dockerfile
+++ b/krm-functions/configinject-fn/Dockerfile
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-FROM golang:1.23.8-alpine@sha256:b7486658b87d34ecf95125e5b97e8dfe86c21f712aa36fc0c702e5dc41dc63e1
+FROM golang:1.24.3-alpine@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 COPY krm-functions/ krm-functions/

--- a/krm-functions/dnn-fn/Dockerfile
+++ b/krm-functions/dnn-fn/Dockerfile
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-FROM golang:1.23.8-alpine@sha256:b7486658b87d34ecf95125e5b97e8dfe86c21f712aa36fc0c702e5dc41dc63e1
+FROM golang:1.24.3-alpine@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 COPY krm-functions/ krm-functions/

--- a/krm-functions/gen-configmap-fn/Dockerfile
+++ b/krm-functions/gen-configmap-fn/Dockerfile
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-FROM golang:1.23.8-alpine@sha256:b7486658b87d34ecf95125e5b97e8dfe86c21f712aa36fc0c702e5dc41dc63e1
+FROM golang:1.24.3-alpine@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 COPY krm-functions/ krm-functions/

--- a/krm-functions/gen-kustomize-res/Dockerfile
+++ b/krm-functions/gen-kustomize-res/Dockerfile
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-FROM golang:1.23.8-alpine@sha256:b7486658b87d34ecf95125e5b97e8dfe86c21f712aa36fc0c702e5dc41dc63e1
+FROM golang:1.24.3-alpine@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 COPY krm-functions/ krm-functions/

--- a/krm-functions/interface-fn/Dockerfile
+++ b/krm-functions/interface-fn/Dockerfile
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-FROM golang:1.23.8-alpine@sha256:b7486658b87d34ecf95125e5b97e8dfe86c21f712aa36fc0c702e5dc41dc63e1
+FROM golang:1.24.3-alpine@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 COPY krm-functions/ krm-functions/

--- a/krm-functions/ipam-fn/Dockerfile
+++ b/krm-functions/ipam-fn/Dockerfile
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-FROM golang:1.23.8-alpine@sha256:b7486658b87d34ecf95125e5b97e8dfe86c21f712aa36fc0c702e5dc41dc63e1
+FROM golang:1.24.3-alpine@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 COPY krm-functions/ krm-functions/

--- a/krm-functions/nad-fn/Dockerfile
+++ b/krm-functions/nad-fn/Dockerfile
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-FROM golang:1.23.8-alpine@sha256:b7486658b87d34ecf95125e5b97e8dfe86c21f712aa36fc0c702e5dc41dc63e1
+FROM golang:1.24.3-alpine@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 COPY krm-functions/ krm-functions/

--- a/krm-functions/nfdeploy-fn/Dockerfile
+++ b/krm-functions/nfdeploy-fn/Dockerfile
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-FROM golang:1.23.8-alpine@sha256:b7486658b87d34ecf95125e5b97e8dfe86c21f712aa36fc0c702e5dc41dc63e1
+FROM golang:1.24.3-alpine@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 COPY krm-functions/ krm-functions/

--- a/krm-functions/ueransim-deploy-fn/Dockerfile
+++ b/krm-functions/ueransim-deploy-fn/Dockerfile
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-FROM golang:1.23.8-alpine@sha256:b7486658b87d34ecf95125e5b97e8dfe86c21f712aa36fc0c702e5dc41dc63e1
+FROM golang:1.24.3-alpine@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 COPY krm-functions/ krm-functions/

--- a/krm-functions/vlan-fn/Dockerfile
+++ b/krm-functions/vlan-fn/Dockerfile
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-FROM golang:1.23.8-alpine@sha256:b7486658b87d34ecf95125e5b97e8dfe86c21f712aa36fc0c702e5dc41dc63e1
+FROM golang:1.24.3-alpine@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 COPY krm-functions/ krm-functions/

--- a/operators/focom-operator/Dockerfile
+++ b/operators/focom-operator/Dockerfile
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 # Build the manager binary
-FROM golang:1.23.8@sha256:ec5612bbd9e96d5b80a8b968cea06a4a9b985fe200ff6da784bf607063273c59 AS builder
+FROM golang:1.24.3@sha256:81bf5927dc91aefb42e2bc3a5abdbe9bb3bae8ba8b107e2a4cf43ce3402534c6 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/operators/focom-operator/go.mod
+++ b/operators/focom-operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/nephio-project/nephio/operators/focom-operator
 
-go 1.24.0
+go 1.24.3
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/operators/nephio-controller-manager/Dockerfile
+++ b/operators/nephio-controller-manager/Dockerfile
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 # Build the manager binary
-FROM golang:1.23.8@sha256:ec5612bbd9e96d5b80a8b968cea06a4a9b985fe200ff6da784bf607063273c59 AS builder
+FROM golang:1.24.3@sha256:81bf5927dc91aefb42e2bc3a5abdbe9bb3bae8ba8b107e2a4cf43ce3402534c6 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/testing/mockeryutils/go.mod
+++ b/testing/mockeryutils/go.mod
@@ -1,6 +1,6 @@
 module github.com/nephio-project/nephio/testing/mockeryutils
 
-go 1.23.8
+go 1.24.3
 
 require github.com/stretchr/testify v1.10.0
 


### PR DESCRIPTION
Bump Golang base image version to 1.24.3

Go version was bumped in this PR - https://github.com/nephio-project/nephio/pull/987
Docker base images were missed.
This is due to the fact that we do not have a docker build validation mech. This is being addrressed with this PR - https://github.com/nephio-project/nephio/pull/990
