### PR TITLE
fix: resolve concurrent state corruption in NetworkController

### DIFF
--- a/controllers/pkg/go.mod
+++ b/controllers/pkg/go.mod
@@ -13,7 +13,6 @@ require (
 	code.gitea.io/sdk/gitea v0.22.1
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
-	github.com/henderiw-nephio/network v0.0.0-20231206051529-4287dc43f8a6
 	github.com/kptdev/kpt v1.0.0-beta.60
 	github.com/kptdev/krm-functions-sdk/go/fn v1.0.1
 	github.com/nephio-project/api v1.0.1-0.20250218114915-854faaf69fd0 //v4.0.0
@@ -26,7 +25,6 @@ require (
 	github.com/nokia/k8s-ipam v0.0.4-0.20230628092530-8a292aec80a4
 	github.com/openconfig/ygot v0.28.3
 	github.com/pkg/errors v0.9.1
-	github.com/srl-labs/ygotsrl/v22 v22.11.1
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.34.1
@@ -38,6 +36,8 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.21.0
 	sigs.k8s.io/yaml v1.6.0
 )
+
+require github.com/henderiw-nephio/network v0.0.0-20231206051529-4287dc43f8a6
 
 require (
 	github.com/42wim/httpsig v1.2.3 // indirect
@@ -88,6 +88,7 @@ require (
 	github.com/prometheus/common v0.67.2 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/srl-labs/ygotsrl/v22 v22.11.1 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect

--- a/controllers/pkg/reconcilers/network/reconciler.go
+++ b/controllers/pkg/reconcilers/network/reconciler.go
@@ -44,7 +44,6 @@ import (
 	"github.com/openconfig/ygot/ygot"
 
 	"github.com/pkg/errors"
-	"github.com/srl-labs/ygotsrl/v22"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/controllers/pkg/reconcilers/network/reconciler.go
+++ b/controllers/pkg/reconcilers/network/reconciler.go
@@ -104,7 +104,6 @@ func (r *reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, c i
 
 	r.APIPatchingApplicator = resource.NewAPIPatchingApplicator(mgr.GetClient())
 	r.finalizer = resource.NewAPIFinalizer(mgr.GetClient(), finalizer)
-	r.devices = map[string]*ygotsrl.Device{}
 	r.VlanClientProxy = cfg.VlanClientProxy
 	r.IpamClientProxy = cfg.IpamClientProxy
 	//r.targets = cfg.Targets
@@ -127,9 +126,7 @@ type reconciler struct {
 	IpamClientProxy clientproxy.Proxy[*ipamv1alpha1.NetworkInstance, *ipamv1alpha1.IPClaim]
 	VlanClientProxy clientproxy.Proxy[*vlanv1alpha1.VLANIndex, *vlanv1alpha1.VLANClaim]
 
-	devices map[string]*ygotsrl.Device
 	//targets   targets.Target
-	resources resources.Resources // get initialized for every cr/reconcile loop
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -182,7 +179,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{Requeue: true}, errors.Wrap(r.Status().Update(ctx, cr), errUpdateStatus)
 	}
 
-	r.resources = resources.New(
+	res := resources.New(
 		r.APIPatchingApplicator,
 		resources.Config{
 			CR:             cr,
@@ -194,21 +191,21 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	)
 
 	log.Info("apply initial resources")
-	if err := r.applyInitialresources(ctx, cr, eps, nodes); err != nil {
+	if err := r.applyInitialresources(ctx, cr, eps, nodes, res); err != nil {
 		log.Error(err, "cannot apply initial resources")
 		cr.SetConditions(infrav1alpha1.Failed(err.Error()))
 		return ctrl.Result{Requeue: true}, errors.Wrap(r.Status().Update(ctx, cr), errUpdateStatus)
 	}
 
 	log.Info("get new resources")
-	if err := r.getNewResources(ctx, cr, eps, nodes); err != nil {
+	if err := r.getNewResources(ctx, cr, eps, nodes, res); err != nil {
 		log.Error(err, "cannot get new resources")
 		cr.SetConditions(infrav1alpha1.Failed(err.Error()))
 		return ctrl.Result{Requeue: true}, errors.Wrap(r.Status().Update(ctx, cr), errUpdateStatus)
 	}
 
 	log.Info("apply all resources")
-	if err := r.resources.APIApply(ctx); err != nil {
+	if err := res.APIApply(ctx); err != nil {
 		log.Error(err, "cannot apply resources to the API")
 		cr.SetConditions(infrav1alpha1.Failed(err.Error()))
 		return ctrl.Result{Requeue: true}, errors.Wrap(r.Status().Update(ctx, cr), errUpdateStatus)
@@ -254,11 +251,11 @@ func (r *reconciler) getProviderNodes(ctx context.Context, topology string) (*no
 	return &nodes.Nodes{NodeList: nos}, nil
 }
 
-func (r *reconciler) applyInitialresources(ctx context.Context, cr *infrav1alpha1.Network, eps *endpoints.Endpoints, nodes *nodes.Nodes) error {
+func (r *reconciler) applyInitialresources(ctx context.Context, cr *infrav1alpha1.Network, eps *endpoints.Endpoints, nodes *nodes.Nodes, res resources.Resources) error {
 	n := network.New(&network.Config{
 		Config:    &infra2v1alpha1.NetworkConfig{},
 		Apply:     true,
-		Resources: r.resources,
+		Resources: res,
 		Endpoints: eps,
 		Nodes:     nodes,
 		Ipam:      ipam.NewIPAM(r.IpamClientProxy),
@@ -269,18 +266,18 @@ func (r *reconciler) applyInitialresources(ctx context.Context, cr *infrav1alpha
 		log.FromContext(ctx).Error(err, "cannot execute network run")
 		return err
 	}
-	if err := r.resources.APIApply(ctx); err != nil {
+	if err := res.APIApply(ctx); err != nil {
 		log.FromContext(ctx).Error(err, "cannot apply resources to the API")
 		return err
 	}
 	return nil
 }
 
-func (r *reconciler) getNewResources(ctx context.Context, cr *infrav1alpha1.Network, eps *endpoints.Endpoints, nodes *nodes.Nodes) error {
+func (r *reconciler) getNewResources(ctx context.Context, cr *infrav1alpha1.Network, eps *endpoints.Endpoints, nodes *nodes.Nodes, res resources.Resources) error {
 	n := network.New(&network.Config{
 		Config:    &infra2v1alpha1.NetworkConfig{},
 		Apply:     false,
-		Resources: r.resources,
+		Resources: res,
 		Endpoints: eps,
 		Nodes:     nodes,
 		Ipam:      ipam.NewIPAM(r.IpamClientProxy),
@@ -337,7 +334,7 @@ func (r *reconciler) getNewResources(ctx context.Context, cr *infrav1alpha1.Netw
 			o.Status.LastAppliedConfig = existingNetwNodeConfig.Status.LastAppliedConfig
 		}
 
-		r.resources.AddNewResource(o)
+		res.AddNewResource(o)
 	}
 	return nil
 }

--- a/operators/nephio-controller-manager/go.mod
+++ b/operators/nephio-controller-manager/go.mod
@@ -11,7 +11,7 @@ replace (
 )
 
 require (
-	github.com/nephio-project/nephio/controllers/pkg v0.0.0-20250915052103-2af16ab1c9e2
+	github.com/nephio-project/nephio/controllers/pkg v0.0.0-20230531154408-a4237c40cb76
 	github.com/nokia/k8s-ipam v0.0.4-0.20230628092530-8a292aec80a4
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546
@@ -75,6 +75,7 @@ require (
 	github.com/nephio-project/nephio/krm-functions/lib v0.0.0-20251208095831-a29054b9701f // indirect
 	github.com/nephio-project/nephio/krm-functions/vlan-fn v0.0.0-00010101000000-000000000000 // indirect
 	github.com/nephio-project/porch v1.5.6-0.20260126092749-2f95846f69f9 // indirect
+	github.com/onsi/ginkgo/v2 v2.23.3 // indirect
 	github.com/openconfig/gnmi v0.9.1 // indirect
 	github.com/openconfig/goyang v1.4.0 // indirect
 	github.com/openconfig/ygot v0.28.3 // indirect

--- a/operators/nephio-controller-manager/go.sum
+++ b/operators/nephio-controller-manager/go.sum
@@ -99,8 +99,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgYQBbFN4U4JNXUNYpxael3UzMyo=
-github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
+github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad h1:a6HEuzUHeKH6hwfN/ZoQgRgVIWFJljSWa/zetS2WTvg=
+github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/protobuf v3.11.4+incompatible/go.mod h1:lUQ9D1ePzbH2PrIS7ob/bjm9HXyH5WHB0Akwh7URreM=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -148,8 +148,8 @@ github.com/nephio-project/porch v1.5.6-0.20260126092749-2f95846f69f9 h1:R1z9UWRH
 github.com/nephio-project/porch v1.5.6-0.20260126092749-2f95846f69f9/go.mod h1:K4/IyrhBpDI/RMXakrEsEqZC2v7OuGupzF+Lg9jbGwg=
 github.com/nokia/k8s-ipam v0.0.4-0.20230628092530-8a292aec80a4 h1:4v0n24tsumwuz1BDGKoGWxZMFtqAlYpI87gE/enMUUI=
 github.com/nokia/k8s-ipam v0.0.4-0.20230628092530-8a292aec80a4/go.mod h1:ZVMmhD6jllAAO3YGIZFXUQbKRtEiIYgZ772bn/1GVz4=
-github.com/onsi/ginkgo/v2 v2.22.0 h1:Yed107/8DjTr0lKCNt7Dn8yQ6ybuDRQoMGrNFKzMfHg=
-github.com/onsi/ginkgo/v2 v2.22.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
+github.com/onsi/ginkgo/v2 v2.23.3 h1:edHxnszytJ4lD9D5Jjc4tiDkPBZ3siDeJJkUZJJVkp0=
+github.com/onsi/ginkgo/v2 v2.23.3/go.mod h1:zXTP6xIp3U8aVuXN8ENK9IXRaTjFnpVB9mGmaSRvxnM=
 github.com/onsi/gomega v1.37.0 h1:CdEG8g0S133B4OswTDC/5XPSzE1OeP29QOioj2PID2Y=
 github.com/onsi/gomega v1.37.0/go.mod h1:8D9+Txp43QWKhM24yyOBEdpkzN8FvJyAwecBgsU4KU0=
 github.com/openconfig/gnmi v0.0.0-20200414194230-1597cc0f2600/go.mod h1:M/EcuapNQgvzxo1DDXHK4tx3QpYM/uG4l591v33jG2A=


### PR DESCRIPTION
###  Bug: Concurrent State Corruption in NetworkController

The `NetworkController` had a critical concurrency flaw where per-reconciliation state was stored on the reconciler struct itself. Since the reconciler is a shared singleton, concurrent reconciliation loops ended up mutating the same `resources` (and previously `devices`) fields.

In a real-world Nephio setup—where multiple `Network` CRs are reconciled simultaneously—this caused state from one reconciliation to leak into another. As a result, configurations such as IPAM allocations, VLAN assignments, or OpenConfig data intended for one network could be incorrectly applied to a different one.

This issue was particularly dangerous because it often **failed silently**: the controller would report a successful reconciliation while leaving the underlying infrastructure in an inconsistent or incorrect state. In some cases, concurrent writes to shared fields could also trigger race conditions and lead to controller panics.

---

###  Fix: Isolate Reconciliation State & Ensure Thread Safety

This PR resolves the issue by eliminating shared mutable state from the reconciler and ensuring that each reconciliation loop operates on its own isolated data.

Key changes:

- **Removed shared fields**: Eliminated `resources` and unused `devices` from the reconciler struct to prevent cross-request mutation.
- **Scoped state locally**: Moved initialization of the `resources` object into the `Reconcile` function so each invocation gets a fresh instance.
- **Explicit dependency passing**: Updated helper functions like `applyInitialResources` and `getNewResources` to accept `resources` as a parameter instead of relying on struct-level state.
- **Cleaned up dead code**: Removed the unused `devices` field to simplify the controller and reduce confusion.

---

###  Result

The `NetworkController` is now thread-safe and behaves correctly under concurrent reconciliation scenarios. Each `Network` CR is processed independently, eliminating cross-resource contamination and ensuring reliable, predictable infrastructure configuration—especially important in Nephio’s GitOps-driven workflows where batch updates are common.