### PR TITLE
fix: persist specialization state and update controller dependencies

### DIFF
--- a/controllers/pkg/reconcilers/generic-specializer/reconciler.go
+++ b/controllers/pkg/reconcilers/generic-specializer/reconciler.go
@@ -289,7 +289,6 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 				if porchv1alpha1.PackageRevisionIsReady(pr.Spec.ReadinessGates, porchcondition.GetPorchConditions(kptfile.Status.Conditions)) {
 					r.recorder.Eventf(pr, corev1.EventTypeNormal, "PackageRevision is Ready", "readiness gates met for %s, in repo %s", pr.Spec.PackageName, pr.Spec.RepositoryName)
-					return ctrl.Result{}, nil
 				}
 			}
 		}
@@ -297,7 +296,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		kptfile := rl.Items.GetRootKptfile()
 		if kptfile == nil {
 			r.recorder.Event(pr, corev1.EventTypeWarning, "ReconcileError", "mandatory Kptfile is missing")
-			log.Error(err, "mandatory Kptfile is missing from the package")
+			log.Error(fmt.Errorf("mandatory Kptfile is missing from the package"), "")
 			return ctrl.Result{}, nil
 		}
 


### PR DESCRIPTION
##  Bug & Fix Summary

### 1. Critical State Loss in Generic Specializer
- **File:** `controllers/pkg/reconcilers/generic-specializer/reconciler.go`  
- **Function:** `Reconcile`

**Bug:**  
An early return (`return ctrl.Result{}, nil`) was triggered when a package reached the *Ready* state. This caused the reconciliation flow to exit before calling `r.porchClient.Update(ctx, prr)`.

**Impact:**  
All in-memory specialization data (e.g., IP allocations, VLAN assignments, and KRM function outputs) was never persisted to the API server. As a result:
- Allocated resources were effectively “lost”
- Backend systems experienced resource leaks
- The controller entered repeated reconciliation loops because the package appeared unspecialized in persistent state

**Fix:**  
- Removed the premature return to ensure the final state is always persisted via `Update`
- Fixed a `log.Error(err, ...)` call that could receive a `nil` error when handling missing Kptfile cases


---

### 2. Resource Mutation Loss in Network Reconciler
- **File:** `controllers/pkg/reconcilers/network/reconciler.go`  
- **Functions:** `getNewResources`, `applyInitialresources`

**Bug:**  
The `Resources` collection was being passed by value to helper functions. This resulted in mutations (e.g., `res.AddNewResource(o)`) being applied only to a local copy instead of the original collection.

**Impact:**  
Newly generated network configurations were silently dropped before reaching the final `APIApply` stage, leading to incomplete or missing infrastructure setup.

**Fix:**  
- Updated function signatures to pass `*resources.Resources` (by pointer)
- Ensured all mutations are applied to the shared collection and correctly persisted


---

### 3. Controller Manager Dependency Reversion
- **File:** `operators/nephio-controller-manager/go.mod`

**Issue:**  
The `controllers/pkg` dependency had been unintentionally downgraded to an older 2023 version, risking API incompatibility and regression of newer features.

**Impact:**  
- Potential mismatches between controller logic and dependency APIs  
- Increased risk of subtle runtime errors and unstable builds  

**Fix:**  
- Restored dependency to `v0.0.0-20250915052103-2af16ab1c9e2`  
- Ran `go mod tidy` to ensure a clean and consistent module state  


---

##  Final Impact

These changes restore correctness and reliability across the Nephio specialization pipeline:

- Ensures all computed infrastructure state (IPs, VLANs, etc.) is **persisted reliably**
- Prevents **silent state loss and backend resource leaks**
- Guarantees **network reconciler applies all generated configurations**
- Stabilizes dependency management and avoids unintended regressions

Overall, this PR fixes critical state-handling flaws and brings the reconciliation flow back to a consistent, production-safe state.

---

## AI Tool Used
 **Gemini 1.5 Pro (Web Interface):** Used for codebase analysis and understanding execution flow.