### PR TITLE
fix: sync KRM function resource deletions in specializers

### DIFF
--- a/controllers/pkg/reconcilers/generic-specializer/reconciler.go
+++ b/controllers/pkg/reconcilers/generic-specializer/reconciler.go
@@ -161,6 +161,13 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{}, errors.Wrap(err, "cannot get resourceList")
 		}
 
+		originalPaths := map[string]struct{}{}
+		for _, o := range rl.Items {
+			if path := o.GetAnnotation(kioutil.PathAnnotation); path != "" {
+				originalPaths[path] = struct{}{}
+			}
+		}
+
 		if porchcondition.HasSpecificTypeConditions(pr.Status.Conditions, kptfilelibv1.GetConditionType(&ipamFor)) {
 			// run the function SDK
 			_, err = ipamkrmfn.Process(rl)
@@ -208,7 +215,13 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{}, nil
 		}
 
+		survivingPaths := map[string]struct{}{}
+
 		for _, o := range rl.Items {
+			if path := o.GetAnnotation(kioutil.PathAnnotation); path != "" {
+				survivingPaths[path] = struct{}{}
+			}
+
 			// TBD what if we create new resources
 			// update only the resource we act upon
 			if o.GetAPIVersion() == ipamFor.APIVersion && o.GetKind() == ipamFor.Kind {
@@ -293,6 +306,8 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			}
 		}
 
+		syncDeletedResources(prr, originalPaths, survivingPaths)
+
 		kptfile := rl.Items.GetRootKptfile()
 		if kptfile == nil {
 			r.recorder.Event(pr, corev1.EventTypeWarning, "ReconcileError", "mandatory Kptfile is missing")
@@ -327,4 +342,12 @@ func (r *reconciler) getClusterName(ctx context.Context, workloadClusterObjs fn.
 		clusterName = workloadCluster.Spec.ClusterName
 	}
 	return clusterName
+}
+
+func syncDeletedResources(prr *porchv1alpha1.PackageRevisionResources, originalPaths, survivingPaths map[string]struct{}) {
+	for path := range originalPaths {
+		if _, exists := survivingPaths[path]; !exists {
+			delete(prr.Spec.Resources, path)
+		}
+	}
 }

--- a/controllers/pkg/reconcilers/generic-specializer/reconciler_test.go
+++ b/controllers/pkg/reconcilers/generic-specializer/reconciler_test.go
@@ -1,0 +1,43 @@
+package genericspecializer
+
+import (
+	"testing"
+
+	porchv1alpha1 "github.com/nephio-project/porch/api/porch/v1alpha1"
+)
+
+func TestSyncDeletedResources(t *testing.T) {
+	prr := &porchv1alpha1.PackageRevisionResources{
+		Spec: porchv1alpha1.PackageRevisionResourcesSpec{
+			Resources: map[string]string{
+				"file1.yaml": "content1",
+				"file2.yaml": "content2",
+				"file3.yaml": "content3",
+			},
+		},
+	}
+
+	originalPaths := map[string]struct{}{
+		"file1.yaml": {},
+		"file2.yaml": {},
+		"file3.yaml": {},
+	}
+
+	// file2 was deleted by KRM function
+	survivingPaths := map[string]struct{}{
+		"file1.yaml": {},
+		"file3.yaml": {},
+	}
+
+	syncDeletedResources(prr, originalPaths, survivingPaths)
+
+	if _, exists := prr.Spec.Resources["file2.yaml"]; exists {
+		t.Errorf("Expected file2.yaml to be deleted, but it still exists")
+	}
+	if _, exists := prr.Spec.Resources["file1.yaml"]; !exists {
+		t.Errorf("Expected file1.yaml to be retained")
+	}
+	if _, exists := prr.Spec.Resources["file3.yaml"]; !exists {
+		t.Errorf("Expected file3.yaml to be retained")
+	}
+}

--- a/controllers/pkg/reconcilers/ipam-specializer/reconciler.go
+++ b/controllers/pkg/reconcilers/ipam-specializer/reconciler.go
@@ -119,6 +119,13 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{}, errors.Wrap(err, "cannot get resourceList")
 		}
 
+		originalPaths := map[string]struct{}{}
+		for _, o := range rl.Items {
+			if path := o.GetAnnotation(kioutil.PathAnnotation); path != "" {
+				originalPaths[path] = struct{}{}
+			}
+		}
+
 		// run the function SDK
 		_, err = r.krmfn.Process(rl)
 		if err != nil {
@@ -126,12 +133,19 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			// TBD if we need to return here + check if kptfile is set
 			//return ctrl.Result{}, errors.Wrap(err, "function run failed")
 		}
+		survivingPaths := map[string]struct{}{}
 		for _, o := range rl.Items {
+			if path := o.GetAnnotation(kioutil.PathAnnotation); path != "" {
+				survivingPaths[path] = struct{}{}
+			}
 			log.Info("resourceList", "data", o.String())
 			// TBD what if we create new resources
 			// update the resources with the latest info
 			prr.Spec.Resources[o.GetAnnotation(kioutil.PathAnnotation)] = o.String()
 		}
+
+		syncDeletedResources(prr, originalPaths, survivingPaths)
+
 		kptfile := rl.Items.GetRootKptfile()
 		if kptfile == nil {
 			log.Error(fmt.Errorf("mandatory Kptfile is missing from the package"), "")
@@ -146,4 +160,12 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	}
 	return ctrl.Result{}, nil
+}
+
+func syncDeletedResources(prr *porchv1alpha1.PackageRevisionResources, originalPaths, survivingPaths map[string]struct{}) {
+	for path := range originalPaths {
+		if _, exists := survivingPaths[path]; !exists {
+			delete(prr.Spec.Resources, path)
+		}
+	}
 }

--- a/controllers/pkg/reconcilers/ipam-specializer/reconciler_test.go
+++ b/controllers/pkg/reconcilers/ipam-specializer/reconciler_test.go
@@ -1,0 +1,43 @@
+package ipamspecializer
+
+import (
+	"testing"
+
+	porchv1alpha1 "github.com/nephio-project/porch/api/porch/v1alpha1"
+)
+
+func TestSyncDeletedResources(t *testing.T) {
+	prr := &porchv1alpha1.PackageRevisionResources{
+		Spec: porchv1alpha1.PackageRevisionResourcesSpec{
+			Resources: map[string]string{
+				"file1.yaml": "content1",
+				"file2.yaml": "content2",
+				"file3.yaml": "content3",
+			},
+		},
+	}
+
+	originalPaths := map[string]struct{}{
+		"file1.yaml": {},
+		"file2.yaml": {},
+		"file3.yaml": {},
+	}
+
+	// file2 was deleted by KRM function
+	survivingPaths := map[string]struct{}{
+		"file1.yaml": {},
+		"file3.yaml": {},
+	}
+
+	syncDeletedResources(prr, originalPaths, survivingPaths)
+
+	if _, exists := prr.Spec.Resources["file2.yaml"]; exists {
+		t.Errorf("Expected file2.yaml to be deleted, but it still exists")
+	}
+	if _, exists := prr.Spec.Resources["file1.yaml"]; !exists {
+		t.Errorf("Expected file1.yaml to be retained")
+	}
+	if _, exists := prr.Spec.Resources["file3.yaml"]; !exists {
+		t.Errorf("Expected file3.yaml to be retained")
+	}
+}

--- a/controllers/pkg/reconcilers/vlan-specializer/reconciler.go
+++ b/controllers/pkg/reconcilers/vlan-specializer/reconciler.go
@@ -117,6 +117,13 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{}, errors.Wrap(err, "cannot get resourceList")
 		}
 
+		originalPaths := map[string]struct{}{}
+		for _, o := range rl.Items {
+			if path := o.GetAnnotation(kioutil.PathAnnotation); path != "" {
+				originalPaths[path] = struct{}{}
+			}
+		}
+
 		// run the function SDK
 		_, err = r.krmfn.Process(rl)
 		if err != nil {
@@ -124,12 +131,19 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			// TBD if we need to return here + check if kptfile is set
 			//return ctrl.Result{}, errors.Wrap(err, "function run failed")
 		}
+		survivingPaths := map[string]struct{}{}
 		for _, o := range rl.Items {
+			if path := o.GetAnnotation(kioutil.PathAnnotation); path != "" {
+				survivingPaths[path] = struct{}{}
+			}
 			log.Info("resourceList", "data", o.String())
 			// TBD what if we create new resources
 			// update the resources with the latest info
 			prr.Spec.Resources[o.GetAnnotation(kioutil.PathAnnotation)] = o.String()
 		}
+
+		syncDeletedResources(prr, originalPaths, survivingPaths)
+
 		kptfile := rl.Items.GetRootKptfile()
 		if kptfile == nil {
 			log.Error(fmt.Errorf("mandatory Kptfile is missing from the package"), "")
@@ -144,4 +158,12 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	}
 	return ctrl.Result{}, nil
+}
+
+func syncDeletedResources(prr *porchv1alpha1.PackageRevisionResources, originalPaths, survivingPaths map[string]struct{}) {
+	for path := range originalPaths {
+		if _, exists := survivingPaths[path]; !exists {
+			delete(prr.Spec.Resources, path)
+		}
+	}
 }

--- a/controllers/pkg/reconcilers/vlan-specializer/reconciler_test.go
+++ b/controllers/pkg/reconcilers/vlan-specializer/reconciler_test.go
@@ -1,0 +1,43 @@
+package vlanspecializer
+
+import (
+	"testing"
+
+	porchv1alpha1 "github.com/nephio-project/porch/api/porch/v1alpha1"
+)
+
+func TestSyncDeletedResources(t *testing.T) {
+	prr := &porchv1alpha1.PackageRevisionResources{
+		Spec: porchv1alpha1.PackageRevisionResourcesSpec{
+			Resources: map[string]string{
+				"file1.yaml": "content1",
+				"file2.yaml": "content2",
+				"file3.yaml": "content3",
+			},
+		},
+	}
+
+	originalPaths := map[string]struct{}{
+		"file1.yaml": {},
+		"file2.yaml": {},
+		"file3.yaml": {},
+	}
+
+	// file2 was deleted by KRM function
+	survivingPaths := map[string]struct{}{
+		"file1.yaml": {},
+		"file3.yaml": {},
+	}
+
+	syncDeletedResources(prr, originalPaths, survivingPaths)
+
+	if _, exists := prr.Spec.Resources["file2.yaml"]; exists {
+		t.Errorf("Expected file2.yaml to be deleted, but it still exists")
+	}
+	if _, exists := prr.Spec.Resources["file1.yaml"]; !exists {
+		t.Errorf("Expected file1.yaml to be retained")
+	}
+	if _, exists := prr.Spec.Resources["file3.yaml"]; !exists {
+		t.Errorf("Expected file3.yaml to be retained")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a critical issue where KRM function pipelines were unable to delete resources due to append-only reconciliation logic in the Specializer controllers.

Previously, controllers (`generic-specializer`, `ipam-specializer`, `vlan-specializer`) rebuilt `prr.Spec.Resources` by iterating only over `rl.Items`. Since deleted resources are absent from `rl.Items`, they were never removed from the map, resulting in stale ("ghost") resources persisting in the package.

This PR introduces explicit deletion synchronization:
- Capture original resource paths before running the KRM pipeline.
- Capture surviving paths after pipeline execution.
- Diff both sets and explicitly remove missing entries using `delete()`.

This ensures full state reconciliation (create/update/delete) instead of append-only behavior.

---

## Bug

**Root Cause:**  
The controller assumed that iterating over the mutated `rl.Items` was sufficient to sync state back to `prr.Spec.Resources`. This ignored deletion semantics entirely.

**Resulting Issue:**  
- Resources deleted by KRM functions (e.g., via `condkptsdk` GC) were silently retained.
- No errors or signals were emitted, leading to misleading "successful" reconciliations.

---

## Fix

- Added path tracking (`originalPaths`, `survivingPaths`)
- Implemented `syncDeletedResources` helper to reconcile deletions
- Applied fix consistently across:
  - `generic-specializer`
  - `ipam-specializer`
  - `vlan-specializer`
- Added unit tests to prevent regression

---

## Impact

- Eliminates ghost resources from PackageRevisions
- Restores correct KRM deletion semantics
- Prevents downstream GitOps drift and infra conflicts (e.g., duplicate IPs)
- Improves reliability of Nephio automation in dynamic/topology-changing environments