### PR TITLE
 fix(generic-specializer): prevent panic on missing kptfile status

### DIFF
--- a/controllers/pkg/reconcilers/generic-specializer/reconciler.go
+++ b/controllers/pkg/reconcilers/generic-specializer/reconciler.go
@@ -279,16 +279,18 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 					log.Error(err, "cannot get gostruct from kubeobject")
 					continue
 				}
-				for _, c := range kptfile.Status.Conditions {
-					if strings.HasPrefix(c.Type, kptfilelibv1.GetConditionType(&vlanFor)+".") ||
-						strings.HasPrefix(c.Type, kptfilelibv1.GetConditionType(&ipamFor)+".") ||
-						strings.HasPrefix(c.Type, kptfilelibv1.GetConditionType(&configInjectFor)+".") {
-						log.Info("generic specializer conditions", "packageName", pr.Spec.PackageName, "repository", pr.Spec.RepositoryName, "status", c.Status, "condition", c.Type, "message", c.Message)
+				if kptfile.Status != nil {
+					for _, c := range kptfile.Status.Conditions {
+						if strings.HasPrefix(c.Type, kptfilelibv1.GetConditionType(&vlanFor)+".") ||
+							strings.HasPrefix(c.Type, kptfilelibv1.GetConditionType(&ipamFor)+".") ||
+							strings.HasPrefix(c.Type, kptfilelibv1.GetConditionType(&configInjectFor)+".") {
+							log.Info("generic specializer conditions", "packageName", pr.Spec.PackageName, "repository", pr.Spec.RepositoryName, "status", c.Status, "condition", c.Type, "message", c.Message)
+						}
 					}
-				}
 
-				if porchv1alpha1.PackageRevisionIsReady(pr.Spec.ReadinessGates, porchcondition.GetPorchConditions(kptfile.Status.Conditions)) {
-					r.recorder.Eventf(pr, corev1.EventTypeNormal, "PackageRevision is Ready", "readiness gates met for %s, in repo %s", pr.Spec.PackageName, pr.Spec.RepositoryName)
+					if porchv1alpha1.PackageRevisionIsReady(pr.Spec.ReadinessGates, porchcondition.GetPorchConditions(kptfile.Status.Conditions)) {
+						r.recorder.Eventf(pr, corev1.EventTypeNormal, "PackageRevision is Ready", "readiness gates met for %s, in repo %s", pr.Spec.PackageName, pr.Spec.RepositoryName)
+					}
 				}
 			}
 		}

--- a/controllers/pkg/reconcilers/generic-specializer/reconciler_nil_status_test.go
+++ b/controllers/pkg/reconcilers/generic-specializer/reconciler_nil_status_test.go
@@ -1,0 +1,77 @@
+package genericspecializer
+
+import (
+	"context"
+	"testing"
+
+	porchv1alpha1 "github.com/nephio-project/porch/api/porch/v1alpha1"
+	"github.com/kptdev/krm-functions-sdk/go/fn"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"k8s.io/client-go/tools/record"
+)
+
+type mockResourceListProcessor struct {
+	err error
+}
+
+func (m *mockResourceListProcessor) Process(rl *fn.ResourceList) (bool, error) {
+	return false, m.err
+}
+
+func TestNilStatusPanicGenericSpecializer(t *testing.T) {
+	scheme := runtime.NewScheme()
+	porchv1alpha1.AddToScheme(scheme)
+
+	pr := &porchv1alpha1.PackageRevision{
+		ObjectMeta: ctrl.ObjectMeta{
+			Name:      "test-pr",
+			Namespace: "default",
+		},
+		Status: porchv1alpha1.PackageRevisionStatus{
+			Conditions: []porchv1alpha1.Condition{},
+		},
+	}
+
+	// Kptfile without status
+	kptfileYaml := `apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: test-pr
+`
+
+	prr := &porchv1alpha1.PackageRevisionResources{
+		ObjectMeta: ctrl.ObjectMeta{
+			Name:      "test-pr",
+			Namespace: "default",
+		},
+		Spec: porchv1alpha1.PackageRevisionResourcesSpec{
+			Resources: map[string]string{
+				"Kptfile": kptfileYaml,
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pr, prr).Build()
+
+	r := &reconciler{
+		apiReader:   fakeClient,
+		porchClient: fakeClient,
+		recorder:    record.NewFakeRecorder(100),
+	}
+
+	req := ctrl.Request{
+		NamespacedName: client.ObjectKey{
+			Name:      "test-pr",
+			Namespace: "default",
+		},
+	}
+
+	// This should not panic
+	_, err := r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Expected nil error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
The generic-specializer was crashing when processing Kptfiles that do not contain a `status` block.  
This PR adds a defensive nil check to safely handle such cases and allow reconciliation to continue.

---

## Root Cause
`kptfile.Status` is an optional pointer.  
The controller assumed it is always present and directly accessed:
```go
kptfile.Status.Conditions
```
When Status == nil, this caused a runtime panic:
`invalid memory address or nil pointer dereference`.

In Go, dereferencing a nil pointer always results in a runtime panic if not checked beforehand, because the pointer does not reference any valid memory location  [oai_citation:0‡codegenes](https://www.codegenes.net/blog/go-panic-runtime-error-invalid-memory-address-or-nil-pointer-dereference/?utm_source=chatgpt.com).

---

## Fix

Added a nil check before accessing `Status.Conditions`:

```go
if kptfile.Status != nil {
    // safely process conditions
}
```
## Testing
- Added unit test: `reconciler_nil_status_test.go`
- Validates that reconciliation succeeds with a status-less Kptfile
- Confirms no panic occurs

---

## Impact
- Prevents controller crashes during reconciliation
- Unblocks PackageRevisions created from fresh or manually authored packages
- Eliminates silent failure loops and stuck resources
- Improves overall reliability of the generic-specializer in production