### PR TITLE
generic-specializer: skip condition walk when Kptfile.Status is nil

### DIFF
--- a/controllers/pkg/reconcilers/generic-specializer/reconciler.go
+++ b/controllers/pkg/reconcilers/generic-specializer/reconciler.go
@@ -279,16 +279,23 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 					log.Error(err, "cannot get gostruct from kubeobject")
 					continue
 				}
-				for _, c := range kptfile.Status.Conditions {
-					if strings.HasPrefix(c.Type, kptfilelibv1.GetConditionType(&vlanFor)+".") ||
-						strings.HasPrefix(c.Type, kptfilelibv1.GetConditionType(&ipamFor)+".") ||
-						strings.HasPrefix(c.Type, kptfilelibv1.GetConditionType(&configInjectFor)+".") {
-						log.Info("generic specializer conditions", "packageName", pr.Spec.PackageName, "repository", pr.Spec.RepositoryName, "status", c.Status, "condition", c.Type, "message", c.Message)
+				// kptv1.KptFile.Status is an optional *Status; newly
+				// cloned repos, raw drafts, and hand-authored packages
+				// reach the reconciler with Status == nil. Ranging over
+				// a nil Conditions slice below used to panic and stall
+				// the whole PackageRevision lifecycle (#1099).
+				if kptfile.Status != nil {
+					for _, c := range kptfile.Status.Conditions {
+						if strings.HasPrefix(c.Type, kptfilelibv1.GetConditionType(&vlanFor)+".") ||
+							strings.HasPrefix(c.Type, kptfilelibv1.GetConditionType(&ipamFor)+".") ||
+							strings.HasPrefix(c.Type, kptfilelibv1.GetConditionType(&configInjectFor)+".") {
+							log.Info("generic specializer conditions", "packageName", pr.Spec.PackageName, "repository", pr.Spec.RepositoryName, "status", c.Status, "condition", c.Type, "message", c.Message)
+						}
 					}
-				}
 
-				if porchv1alpha1.PackageRevisionIsReady(pr.Spec.ReadinessGates, porchcondition.GetPorchConditions(kptfile.Status.Conditions)) {
-					r.recorder.Eventf(pr, corev1.EventTypeNormal, "PackageRevision is Ready", "readiness gates met for %s, in repo %s", pr.Spec.PackageName, pr.Spec.RepositoryName)
+					if porchv1alpha1.PackageRevisionIsReady(pr.Spec.ReadinessGates, porchcondition.GetPorchConditions(kptfile.Status.Conditions)) {
+						r.recorder.Eventf(pr, corev1.EventTypeNormal, "PackageRevision is Ready", "readiness gates met for %s, in repo %s", pr.Spec.PackageName, pr.Spec.RepositoryName)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

`kptv1.KptFile.Status` is defined as `*Status` (optional), so newly cloned repos, raw drafts, and hand-authored packages reach the generic-specializer reconciler with `Status == nil`. The reconciler ranged over `kptfile.Status.Conditions` and then called `porchcondition.GetPorchConditions(kptfile.Status.Conditions)` without checking, so these common shapes panicked and permanently stalled the `PackageRevision` lifecycle (#1099).

Fixes nephio-project/porch#909.

## Change

`controllers/pkg/reconcilers/generic-specializer/reconciler.go`, wrap the condition walk + readiness-gate check in `if kptfile.Status != nil { ... }`. A Kptfile with no status has no conditions to walk anyway, so the ready-gate check on this path is trivially false in that case.

## Testing

- `go build ./controllers/...` passes.
- Manual: fed the reconciler a `PackageRevision` whose Kptfile has no `status` block. Previously it panicked inside the generic-specializer goroutine; now it logs nothing and moves on, and subsequent revisions for the same package progress normally.