### PR TITLE
[security][focom] Verify Kubernetes API TLS certificates by default

### DIFF
--- a/operators/focom-operator/Makefile
+++ b/operators/focom-operator/Makefile
@@ -141,7 +141,7 @@ unit-tests: fmt vet ## Run unit tests only (no external dependencies required).
 		./internal/nbi/models/ \
 		./internal/nbi/validation/
 	@go test -v -coverprofile=coverage-storage.out ./internal/nbi/storage/ \
-		-run "TestInMemory|TestCreateResourceYAML|TestParseResourceYAML|TestRoundTrip|TestExtractResourceID|TestGenerateWorkspaceName|TestSetResource|TestConvertTo|TestCreateKptfile"
+		-run "TestInMemory|TestCreateResourceYAML|TestParseResourceYAML|TestRoundTrip|TestExtractResourceID|TestGenerateWorkspaceName|TestSetResource|TestConvertTo|TestCreateKptfile|TestPorchStorageTLS"
 	@go test -v -coverprofile=coverage-controller.out \
 		./internal/controller/ -run TestValidateTemplateAlignment || echo "Controller tests skipped"
 	@echo ""
@@ -163,7 +163,7 @@ ci-tests: fmt vet ## Run the same tests as CI pipeline (unit tests only, fast ex
 		./internal/nbi/models/ \
 		./internal/nbi/validation/
 	@go test -v -coverprofile=coverage-storage.out ./internal/nbi/storage/ \
-		-run "TestInMemory|TestCreateResourceYAML|TestParseResourceYAML|TestRoundTrip|TestExtractResourceID|TestGenerateWorkspaceName|TestSetResource|TestConvertTo|TestCreateKptfile"
+		-run "TestInMemory|TestCreateResourceYAML|TestParseResourceYAML|TestRoundTrip|TestExtractResourceID|TestGenerateWorkspaceName|TestSetResource|TestConvertTo|TestCreateKptfile|TestPorchStorageTLS"
 	@go test -v -coverprofile=coverage-controller.out \
 		./internal/controller/ -run TestValidateTemplateAlignment || echo "Controller tests skipped"
 	@echo ""

--- a/operators/focom-operator/cmd/main.go
+++ b/operators/focom-operator/cmd/main.go
@@ -33,6 +33,7 @@ import (
 	"fmt"
 	focomv1alpha1 "github.com/nephio-project/nephio/operators/focom-operator/api/focom/v1alpha1"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -73,6 +74,13 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
+// envBool reports whether the named environment variable holds a true value.
+// Unset, empty and unparseable all read as false.
+func envBool(name string) bool {
+	value, err := strconv.ParseBool(os.Getenv(name))
+	return err == nil && value
+}
+
 // initializeNBISystem initializes the complete NBI system with all components
 func initializeNBISystem(mgr ctrl.Manager, nbiConfig *config.NBIConfig) (*nbi.Server, error) {
 	setupLog.Info("Initializing NBI system", "stage", nbiConfig.Stage, "storageBackend", nbiConfig.StorageBackend)
@@ -96,15 +104,23 @@ func initializeNBISystem(mgr ctrl.Manager, nbiConfig *config.NBIConfig) (*nbi.Se
 			repository = "focom-resources"
 		}
 
-		httpsVerify := os.Getenv("PORCH_HTTPS_VERIFY") == "true"
+		// Certificates are verified unless development explicitly opts out.
+		insecureSkipTLSVerify := envBool("UNSAFE_SKIP_TLS_VERIFY")
+		if insecureSkipTLSVerify {
+			setupLog.Info("UNSAFE_SKIP_TLS_VERIFY is set: the Kubernetes API server certificate will NOT be verified " +
+				"and the service account token can be intercepted. Never enable this outside development.")
+		}
+		if _, ok := os.LookupEnv("PORCH_HTTPS_VERIFY"); ok {
+			setupLog.Info("PORCH_HTTPS_VERIFY is no longer supported and is ignored; certificates are always verified " +
+				"unless UNSAFE_SKIP_TLS_VERIFY=true")
+		}
 
 		porchConfig := &storage.PorchStorageConfig{
-			Namespace:   namespace,
-			Repository:  repository,
-			HTTPSVerify: httpsVerify,
-			// KubernetesURL and Token will be auto-detected from environment
-			// KUBERNETES_BASE_URL env var or default to "https://kubernetes.default.svc"
-			// TOKEN env var or service account token file
+			Namespace:             namespace,
+			Repository:            repository,
+			InsecureSkipTLSVerify: insecureSkipTLSVerify,
+			// KubernetesURL, Token and the API server CA are auto-detected from
+			// the environment: KUBERNETES_BASE_URL, TOKEN, KUBERNETES_CA_FILE
 		}
 
 		var err error

--- a/operators/focom-operator/config/manager/manager.yaml
+++ b/operators/focom-operator/config/manager/manager.yaml
@@ -78,10 +78,6 @@ spec:
           value: "default"
         - name: PORCH_REPOSITORY
           value: "focom-resources"
-        - name: KUBERNETES_BASE_URL
-          value: "https://kubernetes.default.svc"
-        - name: PORCH_HTTPS_VERIFY
-          value: "false"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/operators/focom-operator/docs/DEPLOYMENT.md
+++ b/operators/focom-operator/docs/DEPLOYMENT.md
@@ -284,11 +284,16 @@ NBI_STAGE=2                        # Stage 2 (Porch)
 **Optional (with defaults):**
 ```bash
 FOCOM_NAMESPACE=focom-system       # Default namespace for FOCOM resources (default: focom-system)
-KUBERNETES_BASE_URL=https://kubernetes.default.svc  # K8s API URL (auto-detected)
-TOKEN=/var/run/secrets/kubernetes.io/serviceaccount/token  # Auth token (auto-detected)
 PORCH_NAMESPACE=default            # Namespace for PackageRevisions (default: default)
 PORCH_REPOSITORY=focom-resources   # Porch repository name (default: focom-resources)
 ```
+
+In a pod, leave the API server address, token and CA unset: they are taken from
+the service account volume and the address Kubernetes advertises. Setting
+`KUBERNETES_BASE_URL` turns an auto-detected value into a fixed one, and the
+address it must then match is the only one the API server certificate is
+guaranteed to cover. `KUBERNETES_BASE_URL` must be an `https://` URL; a
+plaintext endpoint is refused, because the token is sent with every request.
 
 **Note:** The `FOCOM_NAMESPACE` environment variable sets the default namespace for all FOCOM resources (OCloud, TemplateInfo, FocomProvisioningRequest). This eliminates the need to specify namespace in API request bodies.
 
@@ -1079,8 +1084,8 @@ kubectl scale deployment focom-operator-controller-manager --replicas=3 -n focom
 ### Security
 
 ```bash
-# Enable TLS verification
-# Set in PorchStorageConfig: HTTPSVerify: true
+# TLS verification of the Kubernetes API server is on by default.
+# Never set UNSAFE_SKIP_TLS_VERIFY=true outside development.
 
 # Use network policies
 kubectl apply -f config/network-policies/

--- a/operators/focom-operator/docs/PORCH_SETUP.md
+++ b/operators/focom-operator/docs/PORCH_SETUP.md
@@ -411,6 +411,19 @@ spec:
         #   value: "focom-resources"
 ```
 
+**TLS:** the Kubernetes API server certificate is verified against the CA bundle
+mounted at `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`, so no TLS
+configuration is needed for an in-cluster deployment.
+
+**Proxies:** the client now honours `HTTPS_PROXY` and `NO_PROXY`, like every
+other Kubernetes client. If your cluster exports `HTTPS_PROXY` to workloads,
+make sure `NO_PROXY` covers the API server address; otherwise this connection
+starts going through the proxy. A proxy that terminates TLS will fail the
+handshake, because the cluster CA does not sign its certificate. Leave `KUBERNETES_BASE_URL`
+unset unless you must reach a different endpoint: the operator then uses the
+address from `$KUBERNETES_SERVICE_HOST`, which is the one Kubernetes expects the
+API server certificate to be valid for.
+
 Apply the changes:
 
 ```bash
@@ -459,9 +472,20 @@ export TOKEN=/tmp/kube-token
 # Optional: Override repository name (default: "focom-resources")
 # export PORCH_REPOSITORY=focom-resources
 
+# Optional: CA bundle used to verify the API server certificate. Needed only
+# when running outside the cluster with KUBERNETES_BASE_URL, since a kubeconfig
+# already carries its cluster CA.
+# export KUBERNETES_CA_FILE=/path/to/ca.crt
+
 # Run the operator
 go run ./cmd/main.go
 ```
+
+**TLS:** the API server certificate is always verified. If your development
+cluster presents a certificate you cannot verify, export the cluster CA through
+`KUBERNETES_CA_FILE`. As a last resort `UNSAFE_SKIP_TLS_VERIFY=true` disables
+verification entirely — it sends your bearer token to an unauthenticated
+endpoint and must never be used outside development.
 
 ### Step 6: Verify Operator Startup
 
@@ -811,11 +835,13 @@ git log --oneline
 | `NBI_STORAGE_BACKEND` | Yes | `memory` | Storage backend type (`memory` or `porch`) |
 | `NBI_STAGE` | Yes | `1` | Implementation stage (`1`, `2`, or `3`) |
 | `FOCOM_NAMESPACE` | No | `focom-system` | Default namespace for FOCOM resources (OCloud, TemplateInfo, FocomProvisioningRequest) |
-| `KUBERNETES_BASE_URL` | No | `https://kubernetes.default.svc` | Kubernetes API server URL |
+| `KUBERNETES_BASE_URL` | No | In-cluster API server address | Kubernetes API server URL |
 | `TOKEN` | No | Auto-detected | Authentication token (string or file path) |
 | `KUBECONFIG` | No | `~/.kube/config` | Path to kubeconfig file (local development) |
 | `PORCH_NAMESPACE` | No | `default` | Namespace for PackageRevisions |
 | `PORCH_REPOSITORY` | No | `focom-resources` | Porch repository name |
+| `KUBERNETES_CA_FILE` | No | In-cluster CA | PEM bundle used to verify the API server certificate |
+| `UNSAFE_SKIP_TLS_VERIFY` | No | `false` | Development only: skip verification of the API server certificate |
 
 ### PorchStorageConfig Fields
 
@@ -825,16 +851,17 @@ git log --oneline
 | `Token` | string | No | Auto-detected | Authentication token |
 | `Namespace` | string | Yes | - | Namespace for PackageRevisions |
 | `Repository` | string | Yes | - | Porch repository name |
-| `HTTPSVerify` | bool | No | `false` | Verify HTTPS certificates |
+| `CAFile` | string | No | In-cluster CA | PEM bundle used to verify the API server certificate |
+| `InsecureSkipTLSVerify` | bool | No | `false` | Development only: skip verification of the API server certificate |
 
 ## Best Practices
 
 ### Production Deployments
 
-1. **Use HTTPS with Certificate Verification:**
-   ```go
-   HTTPSVerify: true
-   ```
+1. **Keep Certificate Verification Enabled:**
+   The API server certificate is verified by default. Never set
+   `UNSAFE_SKIP_TLS_VERIFY` in production: it sends the service account token
+   to an endpoint whose identity has not been checked.
 
 2. **Use Private Git Repositories:**
    - Store sensitive configuration in private repositories
@@ -863,10 +890,12 @@ git log --oneline
    - Gitea or GitLab in Docker
    - Faster access, no external dependencies
 
-3. **Disable HTTPS Verification:**
-   ```go
-   HTTPSVerify: false
+3. **Point at the Cluster CA:**
+   ```bash
+   export KUBERNETES_CA_FILE=/path/to/cluster-ca.crt
    ```
+   Certificates stay verified. `UNSAFE_SKIP_TLS_VERIFY=true` turns verification
+   off if you have no CA to hand, and logs a warning at startup.
 
 4. **Use Automatic Token Resolution:**
    - Let the operator extract token from kubeconfig

--- a/operators/focom-operator/internal/nbi/integration_test.go
+++ b/operators/focom-operator/internal/nbi/integration_test.go
@@ -87,7 +87,8 @@ func NewTestServerWithConfig(config *TestConfig) *TestServer {
 			Token:                  config.Porch.Token,
 			Namespace:              config.Porch.Namespace,
 			Repository:             config.Porch.Repository,
-			HTTPSVerify:            config.Porch.HTTPSVerify,
+			CAFile:                 config.Porch.CAFile,
+			InsecureSkipTLSVerify:  config.Porch.InsecureSkipTLSVerify,
 			PackageRevisionTimeout: 120 * time.Second, // Use 2 minutes for tests (default is 30s)
 		}
 		storageImpl, err = storage.NewPorchStorage(porchConfig)

--- a/operators/focom-operator/internal/nbi/storage/porch.go
+++ b/operators/focom-operator/internal/nbi/storage/porch.go
@@ -19,14 +19,19 @@ package storage
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -46,6 +51,24 @@ const (
 	PorchLifecyclePublished = "Published"
 )
 
+// Kubernetes API connection defaults
+const (
+	// defaultKubernetesURL is used only outside a cluster; see buildRESTConfig.
+	defaultKubernetesURL = "https://kubernetes.default.svc"
+	// defaultInClusterCAFile is where Kubernetes publishes the API server CA
+	// in a pod.
+	defaultInClusterCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	// defaultRequestTimeout bounds every call to the Kubernetes API.
+	defaultRequestTimeout = 30 * time.Second
+)
+
+// inClusterCAFile is a variable so that tests can point it somewhere that
+// definitely does not exist. Kubernetes mounts a CA bundle at the default path
+// in any pod with the service account credential attached, including the one a
+// test runs in, so a test asserting that the bundle is absent would otherwise
+// pass on a laptop and fail in CI.
+var inClusterCAFile = defaultInClusterCAFile
+
 // PorchStorage implements StorageInterface using Nephio Porch via REST API
 type PorchStorage struct {
 	httpClient             *http.Client
@@ -62,8 +85,9 @@ type PorchStorageConfig struct {
 	Token                  string        // Service account token (optional, will auto-detect)
 	Namespace              string        // Namespace for PackageRevisions (usually "default")
 	Repository             string        // Porch repository name (e.g., "focom-resources")
-	HTTPSVerify            bool          // Whether to verify HTTPS certificates (default: false for dev)
-	UseKubeconfig          bool          // Use kubeconfig for authentication (handles exec, certs, etc.)
+	CAFile                 string        // CA bundle verifying the API server (optional, defaults to KUBERNETES_CA_FILE env or the in-cluster CA)
+	InsecureSkipTLSVerify  bool          // Development only: skip API server certificate verification, exposing the token (default: false)
+	UseKubeconfig          bool          // Use kubeconfig for authentication (client certs; exec plugins are not yet honoured, see #1171)
 	Kubeconfig             string        // Path to kubeconfig file (optional, defaults to KUBECONFIG env or ~/.kube/config)
 	PackageRevisionTimeout time.Duration // Timeout for waiting for PackageRevision operations (optional, default: 30s)
 }
@@ -108,19 +132,27 @@ func newPorchStorageFromKubeconfig(config *PorchStorageConfig) (*PorchStorage, e
 		return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
 	}
 
+	if err := validateAPIServerURL(restConfig.Host); err != nil {
+		return nil, err
+	}
+
+	// Set on the config: HTTPClientFor may return the shared http.DefaultClient.
+	restConfig.Timeout = defaultRequestTimeout
+
 	// Create HTTP client with kubeconfig's transport (handles auth automatically)
+	if err := pinConfiguredCA(restConfig); err != nil {
+		return nil, err
+	}
+
 	httpClient, err := rest.HTTPClientFor(restConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP client from kubeconfig: %w", err)
 	}
 
-	// Set timeout
-	httpClient.Timeout = 30 * time.Second
-
 	// Set default PackageRevision timeout if not specified
 	prTimeout := config.PackageRevisionTimeout
 	if prTimeout == 0 {
-		prTimeout = 30 * time.Second
+		prTimeout = defaultRequestTimeout
 	}
 
 	return &PorchStorage{
@@ -135,16 +167,7 @@ func newPorchStorageFromKubeconfig(config *PorchStorageConfig) (*PorchStorage, e
 
 // newPorchStorageWithToken creates PorchStorage using token-based authentication (original method)
 func newPorchStorageWithToken(config *PorchStorageConfig) (*PorchStorage, error) {
-	// 1. Get Kubernetes API URL (env var or default)
-	kubernetesURL := config.KubernetesURL
-	if kubernetesURL == "" {
-		kubernetesURL = os.Getenv("KUBERNETES_BASE_URL")
-		if kubernetesURL == "" {
-			kubernetesURL = "https://kubernetes.default.svc"
-		}
-	}
-
-	// 2. Get service account token (env var, file, or kubeconfig)
+	// 1. Get service account token (env var, file, or kubeconfig)
 	token := config.Token
 	if token == "" {
 		var err error
@@ -154,30 +177,243 @@ func newPorchStorageWithToken(config *PorchStorageConfig) (*PorchStorage, error)
 		}
 	}
 
-	// 3. Create HTTP client with timeout and TLS config
-	httpClient := &http.Client{
-		Timeout: 30 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: !config.HTTPSVerify, // #nosec G402 -- configurable TLS verification for dev environments
-			},
-		},
+	// 2. Get the address and TLS settings (verifies the API server by default)
+	restConfig, err := buildRESTConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := pinConfiguredCA(restConfig); err != nil {
+		return nil, err
+	}
+
+	httpClient, err := rest.HTTPClientFor(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
 	}
 
 	// Set default PackageRevision timeout if not specified
 	prTimeout := config.PackageRevisionTimeout
 	if prTimeout == 0 {
-		prTimeout = 30 * time.Second
+		prTimeout = defaultRequestTimeout
 	}
 
 	return &PorchStorage{
 		httpClient:             httpClient,
-		kubernetesURL:          kubernetesURL,
+		kubernetesURL:          restConfig.Host,
 		token:                  token,
 		namespace:              config.Namespace,
 		repository:             config.Repository,
 		packageRevisionTimeout: prTimeout,
 	}, nil
+}
+
+// explicitKubernetesURL returns the configured API server URL, or "" if unset.
+func explicitKubernetesURL(config *PorchStorageConfig) string {
+	if config.KubernetesURL != "" {
+		return config.KubernetesURL
+	}
+	return os.Getenv("KUBERNETES_BASE_URL")
+}
+
+// validateAPIServerURL rejects endpoints that cannot carry a bearer token
+// safely. Plaintext is refused outright: skipping certificate verification is
+// an explicit opt-in, sending the token in the clear is never one.
+func validateAPIServerURL(host string) error {
+	parsed, err := url.Parse(host)
+	if err != nil {
+		return fmt.Errorf("invalid Kubernetes API URL %q: %w", host, err)
+	}
+	switch {
+	case parsed.Scheme != "https":
+		return fmt.Errorf("the Kubernetes API URL %q must use https, the service account token is sent with every request", host)
+	case parsed.Host == "":
+		return fmt.Errorf("the Kubernetes API URL %q has no host", host)
+	case !isUnambiguousHost(parsed.Hostname()):
+		return fmt.Errorf("the Kubernetes API URL %q has an unusable host %q", host, parsed.Hostname())
+	case parsed.User != nil:
+		return fmt.Errorf("the Kubernetes API URL %q must not embed credentials", host)
+	case parsed.RawQuery != "" || parsed.ForceQuery || strings.Contains(host, "#"):
+		// A bare "?" survives as ForceQuery and a bare "#" as an empty
+		// Fragment, and both then swallow the API path this is joined to.
+		return fmt.Errorf("the Kubernetes API URL %q must not carry a query or fragment", host)
+	}
+	if _, err := effectiveAPIServerPort(parsed); err != nil {
+		return fmt.Errorf("the Kubernetes API URL %q has an %w", host, err)
+	}
+	return nil
+}
+
+// hostLabel matches one letter-digit-hyphen label, which is all a hostname may
+// be. Anything a second parser could read differently is outside it.
+var hostLabel = regexp.MustCompile(`^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?$`)
+
+// isUnambiguousHost reports whether every parser reads host as the same host.
+// net/http keeps a name like "ⓔxample.com" as written while the transport maps
+// it to "example.com" before dialling, so the address checked would not be the
+// one used. Allowing a shape is steadier than refusing characters by name.
+func isUnambiguousHost(host string) bool {
+	if net.ParseIP(host) != nil {
+		return true
+	}
+	if host == "" || len(host) > 253 {
+		return false
+	}
+	for _, label := range strings.Split(strings.TrimSuffix(host, "."), ".") {
+		if !hostLabel.MatchString(label) {
+			return false
+		}
+	}
+	return true
+}
+
+// pinConfiguredCA replaces a named bundle with the bytes that were checked.
+//
+// client-go loads a CA file by appending it to an empty pool and keeping the
+// pool only if something was added, so a file of zero bytes leaves RootCAs nil
+// and the connection falls back to whatever the container image trusts. That
+// is not what naming a bundle asks for: it is a wider trust boundary than the
+// cluster CA, arrived at silently. A file that cannot be parsed is refused
+// already; an empty one has to be refused too.
+//
+// The bytes that were parsed are the bytes installed, and the path is cleared,
+// so the transport cannot read a different file than the one checked.
+func pinConfiguredCA(restConfig *rest.Config) error {
+	if restConfig.Insecure || (len(restConfig.CAData) == 0 && restConfig.CAFile == "") {
+		return nil
+	}
+
+	data, source := restConfig.CAData, "the configured certificate-authority-data"
+	if len(data) == 0 {
+		source = restConfig.CAFile
+		var err error
+		// The call is its own statement: gosec attaches #nosec to a statement,
+		// and inside an if initialiser the annotation lands on the if rather
+		// than on the read, so v2.22.0 reports G304 anyway.
+		data, err = os.ReadFile(source) // #nosec G304 G703 -- operator configuration
+		if err != nil {
+			return fmt.Errorf("cannot read the Kubernetes API CA %q: %w", source, err)
+		}
+	}
+
+	if !x509.NewCertPool().AppendCertsFromPEM(data) {
+		return fmt.Errorf("the Kubernetes API CA %q holds no certificate", source)
+	}
+
+	restConfig.CAData = data
+	restConfig.CAFile = ""
+	return nil
+}
+
+// effectiveAPIServerPort returns the port as a number, or an error if it is
+// not one an endpoint can have. url.Parse only checks the port is digits, so
+// ":0443" and ":443" both parse and compare unequal as strings while naming
+// the same endpoint, and ":65536" parses while nothing can listen on it.
+func effectiveAPIServerPort(parsed *url.URL) (string, error) {
+	port := parsed.Port()
+	if port == "" {
+		return "443", nil
+	}
+	number, err := strconv.ParseUint(port, 10, 16)
+	if err != nil || number == 0 {
+		return "", fmt.Errorf("invalid port %q", port)
+	}
+	return strconv.FormatUint(number, 10), nil
+}
+
+// apiServerOrigin reduces a URL to the endpoint its certificate is issued for.
+// https://host and https://host:443 name one endpoint, as do the short and long
+// spellings of an IPv6 address, so comparing URLs as written would send
+// equivalent addresses down different trust paths.
+func apiServerOrigin(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if ip := net.ParseIP(host); ip != nil {
+		host = ip.String()
+	}
+	port, err := effectiveAPIServerPort(parsed)
+	if err != nil {
+		return rawURL
+	}
+	return strings.ToLower(parsed.Scheme) + "://" + net.JoinHostPort(host, port)
+}
+
+// buildRESTConfig returns the address and TLS settings for the Kubernetes API.
+// In a pod the cluster CA has to load: InClusterConfig only logs a bundle it
+// cannot read, so the alternative is not a failed handshake but silent
+// promotion to whatever the container image happens to trust.
+// The client this builds honours HTTPS_PROXY and NO_PROXY, because client-go
+// installs http.ProxyFromEnvironment. The transport this replaces set no proxy
+// at all, so on a cluster that exports HTTPS_PROXY without a NO_PROXY entry for
+// the API server, this connection starts going through it. That matches the
+// manager's own client in the same binary, which has always used client-go, and
+// a proxy that terminates TLS now fails the handshake against the pinned
+// cluster CA rather than quietly reading the token.
+func buildRESTConfig(config *PorchStorageConfig) (*rest.Config, error) {
+	restConfig := &rest.Config{Timeout: defaultRequestTimeout}
+
+	// Read from the environment rather than through rest.InClusterConfig,
+	// which reads the fixed service account token before it will hand back the
+	// host and CA. A pod that turns off the default mount and projects its
+	// token elsewhere supplies everything needed here and would still be
+	// refused. Kubernetes only promises a certificate valid for the address it
+	// advertises, so that is the one to use.
+	host, port := os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")
+	inClusterHost := ""
+	if host != "" || port != "" {
+		if host == "" || port == "" {
+			return nil, errors.New("KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be set together")
+		}
+		inClusterHost = "https://" + net.JoinHostPort(host, port)
+	}
+
+	restConfig.Host = inClusterHost
+	if kubernetesURL := explicitKubernetesURL(config); kubernetesURL != "" {
+		restConfig.Host = kubernetesURL
+	}
+	if restConfig.Host == "" {
+		restConfig.Host = defaultKubernetesURL
+	}
+	// Before the bundle is chosen rather than after the config is returned:
+	// which CA an address gets is a decision about an endpoint, and an
+	// endpoint that cannot carry a token is not one.
+	if err := validateAPIServerURL(restConfig.Host); err != nil {
+		return nil, err
+	}
+
+	caFile := config.CAFile
+	if caFile == "" {
+		caFile = os.Getenv("KUBERNETES_CA_FILE")
+	}
+	if config.InsecureSkipTLSVerify && caFile != "" {
+		return nil, errors.New("a CA bundle and InsecureSkipTLSVerify are mutually exclusive")
+	}
+	// The cluster bundle is issued for the cluster's own API server, reachable
+	// both at the advertised address and at the in-cluster name. Any other
+	// endpoint is a different server and keeps the system roots. Required
+	// rather than best effort: falling back would widen the trust boundary
+	// instead of failing.
+	origin := apiServerOrigin(restConfig.Host)
+	if caFile == "" && inClusterHost != "" &&
+		(origin == apiServerOrigin(inClusterHost) ||
+			origin == apiServerOrigin(defaultKubernetesURL)) {
+		caFile = inClusterCAFile
+	}
+
+	if config.InsecureSkipTLSVerify {
+		// Drop the bundle rather than the whole TLS config: client-go rejects
+		// the two together, but ServerName and client certs must survive.
+		restConfig.Insecure = true
+		restConfig.CAFile = ""
+		restConfig.CAData = nil
+	} else {
+		restConfig.CAFile = caFile
+	}
+
+	return restConfig, nil
 }
 
 // resolveToken attempts to resolve the authentication token from multiple sources
@@ -300,7 +536,9 @@ func (s *PorchStorage) makeRequest(ctx context.Context, method, path string, bod
 		}
 	}
 
-	url := fmt.Sprintf("%s%s", s.kubernetesURL, path)
+	// Trimmed on both sides: a base URL that ends in "/" produced "//apis",
+	// which the API server answers with a redirect this client refuses.
+	url := strings.TrimRight(s.kubernetesURL, "/") + "/" + strings.TrimLeft(path, "/")
 	var req *http.Request
 
 	if len(reqBody) > 0 {

--- a/operators/focom-operator/internal/nbi/storage/porch_test.go
+++ b/operators/focom-operator/internal/nbi/storage/porch_test.go
@@ -19,7 +19,9 @@ package storage
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"net/http"
@@ -63,7 +65,6 @@ func TestNewPorchStorage_WithConfig(t *testing.T) {
 		Token:         "test-token-12345",
 		Namespace:     "test-namespace",
 		Repository:    "test-repo",
-		HTTPSVerify:   false,
 	}
 
 	storage, err := NewPorchStorage(config)
@@ -124,6 +125,8 @@ func TestNewPorchStorage_WithTokenFile(t *testing.T) {
 func TestNewPorchStorage_DefaultKubernetesURL(t *testing.T) {
 	// Ensure no env var is set
 	os.Unsetenv("KUBERNETES_BASE_URL")
+	// The default only applies outside a cluster.
+	isolateClusterEnv(t)
 
 	config := &PorchStorageConfig{
 		Token:      "test-token",
@@ -162,6 +165,596 @@ func TestNewPorchStorage_MissingRepository(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, storage)
 	assert.Contains(t, err.Error(), "repository is required")
+}
+
+// TLS verification regression tests. Unlike the TEMPORARY set above, these pin
+// a security default and should outlive the seed implementation.
+
+// isolateClusterEnv hides ambient cluster config so the tests see the defaults.
+// TestMain clears the variables the kubelet injects, so that a run inside a
+// pod tests the same thing a run on a laptop does. Without this the suite
+// picks up whichever cluster it happens to be running in, and tests about
+// token resolution start failing on a missing CA bundle. Individual tests
+// still set these with t.Setenv when the environment is what they are about.
+func TestMain(m *testing.M) {
+	for _, key := range []string{
+		"KUBERNETES_SERVICE_HOST",
+		"KUBERNETES_SERVICE_PORT",
+		"KUBERNETES_BASE_URL",
+		"KUBERNETES_CA_FILE",
+		"UNSAFE_SKIP_TLS_VERIFY",
+		"PORCH_HTTPS_VERIFY",
+	} {
+		if err := os.Unsetenv(key); err != nil {
+			panic(err)
+		}
+	}
+	os.Exit(m.Run())
+}
+
+func isolateClusterEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+	t.Setenv("KUBERNETES_BASE_URL", "")
+	t.Setenv("KUBERNETES_CA_FILE", "")
+
+	// The default path is a real file in any pod that mounts the service
+	// account credential, so a test that assumes its absence would behave one
+	// way on a laptop and the other way in CI. Point it somewhere empty.
+	original := inClusterCAFile
+	inClusterCAFile = filepath.Join(t.TempDir(), "absent-ca.crt")
+	t.Cleanup(func() { inClusterCAFile = original })
+}
+
+// withInClusterCA points the fixed in-cluster CA path at the given file for the
+// duration of one test.
+func withInClusterCA(t *testing.T, path string) {
+	t.Helper()
+	original := inClusterCAFile
+	inClusterCAFile = path
+	t.Cleanup(func() { inClusterCAFile = original })
+}
+
+// newPorchTLSServer starts an HTTPS stand-in for the Kubernetes API. Its
+// certificate is signed by an authority no trust store knows, like a cluster CA.
+func newPorchTLSServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"apiVersion": "porch.kpt.dev/v1alpha1",
+			"kind":       "PackageRevisionList",
+			"items":      []interface{}{},
+		})
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// writeCAFile writes cert to a PEM bundle usable as a trusted CA.
+func writeCAFile(t *testing.T, cert *x509.Certificate) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ca.crt")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+	require.NoError(t, os.WriteFile(path, pemBytes, 0600))
+	return path
+}
+
+// TestPorchStorageTLS_VerifiedByDefault checks that the token is not sent to
+// an API server whose certificate cannot be verified.
+func TestPorchStorageTLS_VerifiedByDefault(t *testing.T) {
+	isolateClusterEnv(t)
+	server := newPorchTLSServer(t)
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL: server.URL,
+		Token:         "test-token",
+		Namespace:     "default",
+		Repository:    "focom-resources",
+	})
+	require.NoError(t, err)
+
+	err = storage.HealthCheck(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "x509: certificate signed by unknown authority")
+}
+
+// TestPorchStorageTLS_TrustsConfiguredCA checks that CAFile is used.
+func TestPorchStorageTLS_TrustsConfiguredCA(t *testing.T) {
+	isolateClusterEnv(t)
+	server := newPorchTLSServer(t)
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL: server.URL,
+		Token:         "test-token",
+		Namespace:     "default",
+		Repository:    "focom-resources",
+		CAFile:        writeCAFile(t, server.Certificate()),
+	})
+	require.NoError(t, err)
+
+	assert.NoError(t, storage.HealthCheck(context.Background()))
+}
+
+// TestPorchStorageTLS_CAFileFromEnv checks that KUBERNETES_CA_FILE is used.
+func TestPorchStorageTLS_CAFileFromEnv(t *testing.T) {
+	isolateClusterEnv(t)
+	server := newPorchTLSServer(t)
+	t.Setenv("KUBERNETES_CA_FILE", writeCAFile(t, server.Certificate()))
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL: server.URL,
+		Token:         "test-token",
+		Namespace:     "default",
+		Repository:    "focom-resources",
+	})
+	require.NoError(t, err)
+
+	assert.NoError(t, storage.HealthCheck(context.Background()))
+}
+
+// TestPorchStorageTLS_UnreadableCAFile checks that a broken bundle fails early.
+func TestPorchStorageTLS_UnreadableCAFile(t *testing.T) {
+	isolateClusterEnv(t)
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL: "https://test-k8s-api:6443",
+		Token:         "test-token",
+		Namespace:     "default",
+		Repository:    "focom-resources",
+		CAFile:        filepath.Join(t.TempDir(), "missing.crt"),
+	})
+	assert.Error(t, err)
+	assert.Nil(t, storage)
+}
+
+// TestPorchStorageTLS_RejectsPlainHTTP checks that a plaintext endpoint is
+// refused outright, so the bearer token never reaches it.
+func TestPorchStorageTLS_RejectsPlainHTTP(t *testing.T) {
+	isolateClusterEnv(t)
+	var reached int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached++
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	for _, insecure := range []bool{false, true} {
+		storage, err := NewPorchStorage(&PorchStorageConfig{
+			KubernetesURL:         server.URL,
+			Token:                 "test-token",
+			Namespace:             "default",
+			Repository:            "focom-resources",
+			InsecureSkipTLSVerify: insecure,
+		})
+		require.Error(t, err, "insecure=%v", insecure)
+		assert.Nil(t, storage)
+		assert.Contains(t, err.Error(), "must use https")
+	}
+	assert.Zero(t, reached, "the plaintext server must never be contacted")
+}
+
+// TestPorchStorageTLS_RejectsUnusableURL checks the remaining endpoint shapes
+// that cannot carry a credential safely.
+func TestPorchStorageTLS_RejectsUnusableURL(t *testing.T) {
+	isolateClusterEnv(t)
+	for name, kubernetesURL := range map[string]string{
+		"hostless":    "https://",
+		"relative":    "kubernetes.default.svc",
+		"malformed":   "https://%zz",
+		"credentials": "https://user:pass@api.example.com:6443",
+		"query":       "https://api.example.com:6443?token=x",
+	} {
+		t.Run(name, func(t *testing.T) {
+			storage, err := NewPorchStorage(&PorchStorageConfig{
+				KubernetesURL: kubernetesURL,
+				Token:         "test-token",
+				Namespace:     "default",
+				Repository:    "focom-resources",
+			})
+			assert.Error(t, err)
+			assert.Nil(t, storage)
+		})
+	}
+}
+
+// TestPorchStorageTLS_RejectsCAWithSkipVerify checks that a configured bundle
+// is not silently discarded by the escape hatch.
+func TestPorchStorageTLS_RejectsCAWithSkipVerify(t *testing.T) {
+	isolateClusterEnv(t)
+	server := newPorchTLSServer(t)
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL:         server.URL,
+		Token:                 "test-token",
+		Namespace:             "default",
+		Repository:            "focom-resources",
+		CAFile:                writeCAFile(t, server.Certificate()),
+		InsecureSkipTLSVerify: true,
+	})
+	assert.Error(t, err)
+	assert.Nil(t, storage)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+// TestPorchStorageTLS_CustomTokenInPod checks that a pod which turns off the
+// default token mount and projects its credential elsewhere still starts. The
+// standard token path is deliberately not consulted: everything needed is
+// supplied, so requiring that file as well would refuse a valid deployment.
+func TestPorchStorageTLS_CustomTokenInPod(t *testing.T) {
+	isolateClusterEnv(t)
+	server := newPorchTLSServer(t)
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL: server.URL,
+		Token:         "test-token",
+		Namespace:     "default",
+		Repository:    "focom-resources",
+		CAFile:        writeCAFile(t, server.Certificate()),
+	})
+	require.NoError(t, err)
+	assert.NoError(t, storage.HealthCheck(context.Background()))
+}
+
+// TestPorchStorageTLS_InPodWithoutCAFailsClosed checks that a pod with no CA
+// available refuses to start rather than falling back to the system roots.
+func TestPorchStorageTLS_InPodWithoutCAFailsClosed(t *testing.T) {
+	isolateClusterEnv(t)
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		Token:      "test-token",
+		Namespace:  "default",
+		Repository: "focom-resources",
+	})
+	require.Error(t, err)
+	assert.Nil(t, storage)
+	assert.Contains(t, err.Error(), inClusterCAFile)
+}
+
+// TestPorchStorageTLS_InPodWithMalformedCAFailsClosed checks the bundle at the
+// fixed in-cluster path is loaded rather than merely found. This case only
+// became testable once that path stopped being a constant.
+func TestPorchStorageTLS_InPodWithMalformedCAFailsClosed(t *testing.T) {
+	isolateClusterEnv(t)
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	malformed := filepath.Join(t.TempDir(), "ca.crt")
+	require.NoError(t, os.WriteFile(malformed, []byte("not a certificate\n"), 0600))
+	withInClusterCA(t, malformed)
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		Token:      "test-token",
+		Namespace:  "default",
+		Repository: "focom-resources",
+	})
+	require.Error(t, err)
+	assert.Nil(t, storage)
+}
+
+// TestPorchStorageTLS_PartialServiceEnvIsRefused checks that half an in-cluster
+// environment is a configuration error rather than a silent fallback.
+// TestPorchStorageTLS_OtherEndpointKeepsSystemRoots checks that the cluster
+// bundle follows the cluster's own address. A pod pointed at some other server
+// gets the system roots, so the certificate is still checked, just against the
+// right authorities.
+func TestPorchStorageTLS_OtherEndpointKeepsSystemRoots(t *testing.T) {
+	isolateClusterEnv(t)
+	server := newPorchTLSServer(t)
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL: server.URL,
+		Token:         "test-token",
+		Namespace:     "default",
+		Repository:    "focom-resources",
+	})
+	require.NoError(t, err, "should not have looked for the cluster CA")
+
+	err = storage.HealthCheck(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "certificate")
+}
+
+// TestPorchStorageTLS_ClusterNameUsesClusterCA covers the other spelling of
+// the same server: the in-cluster DNS name is served by the cluster, so it
+// takes the cluster bundle and fails closed without it.
+func TestPorchStorageTLS_ClusterNameUsesClusterCA(t *testing.T) {
+	isolateClusterEnv(t)
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL: defaultKubernetesURL,
+		Token:         "test-token",
+		Namespace:     "default",
+		Repository:    "focom-resources",
+	})
+	require.Error(t, err)
+	assert.Nil(t, storage)
+	assert.Contains(t, err.Error(), inClusterCAFile)
+}
+
+// TestPorchStorageTLS_EquivalentClusterAddresses covers the spellings of the
+// cluster's own endpoint. The certificate does not change with the notation, so
+// neither should the bundle chosen to check it.
+// TestPorchStorageTLS_UnusableHostsAreRefused covers the shapes a second parser reads
+// differently. net/http keeps these as written and the transport maps them
+// before dialling, so the address checked would not be the one used.
+func TestPorchStorageTLS_UnusableHostsAreRefused(t *testing.T) {
+	for _, host := range []string{
+		"https://10.96.0.1%2eevil.example",
+		"https://\u24d4xample.com",
+		"https://ex\uff41mple.com",
+		"https://10.0.0.1\u3002evil",
+		"https://10.96.0.1\\proxy",
+		"https://10.96.0.1 /proxy",
+		"https://10.96.0.1_x",
+		"https://10.96.0.1:0",
+		"https://10.96.0.1:00",
+		"https://10.96.0.1:65536",
+		"https://10.96.0.1:999999999",
+		"https://10.96.0.1?",
+		"https://10.96.0.1#",
+	} {
+		assert.Error(t, validateAPIServerURL(host), "%s should be refused", host)
+	}
+
+	for _, host := range []string{
+		"https://10.96.0.1:443",
+		"https://[fd00::1]:443",
+		"https://kubernetes.default.svc",
+		"https://KUBERNETES.DEFAULT.SVC",
+		"https://example.com.",
+		"https://a-b.example-1.com:6443",
+	} {
+		assert.NoError(t, validateAPIServerURL(host), "%s should be accepted", host)
+	}
+}
+
+// TestPorchStorageTLS_APIServerOrigin pins the helper on its own terms. Its callers happen to
+// have rejected plaintext by the time they reach it, so a caller-level test
+// cannot tell whether the scheme is part of the endpoint. It is.
+func TestPorchStorageTLS_APIServerOrigin(t *testing.T) {
+	same := [][2]string{
+		{"https://10.96.0.1", "https://10.96.0.1:443"},
+		{"https://kubernetes.default.svc", "https://KUBERNETES.DEFAULT.SVC:443"},
+		{"https://[::ffff:a60:1]:443", "https://[0:0:0:0:0:ffff:a60:1]:443"},
+		{"https://host:6443/api", "https://host:6443/healthz"},
+	}
+	for _, pair := range same {
+		assert.Equal(t, apiServerOrigin(pair[0]), apiServerOrigin(pair[1]),
+			"%s and %s are one endpoint", pair[0], pair[1])
+	}
+
+	same = append(same,
+		[2]string{"https://10.96.0.1:443", "https://10.96.0.1:0443"},
+		[2]string{"https://10.96.0.1:443", "https://10.96.0.1:00443"},
+	)
+	for _, pair := range same[len(same)-2:] {
+		assert.Equal(t, apiServerOrigin(pair[0]), apiServerOrigin(pair[1]),
+			"%s and %s are one endpoint", pair[0], pair[1])
+	}
+
+	differ := [][2]string{
+		{"https://10.96.0.1:443", "http://10.96.0.1:443"},
+		{"https://10.96.0.1:443", "https://10.96.0.1:6443"},
+		{"https://10.96.0.1:443", "https://10.96.0.2:443"},
+		{"https://kubernetes.default.svc", "https://kubernetes.default.svc.other"},
+	}
+	for _, pair := range differ {
+		assert.NotEqual(t, apiServerOrigin(pair[0]), apiServerOrigin(pair[1]),
+			"%s and %s are different endpoints", pair[0], pair[1])
+	}
+}
+
+// TestPorchStorageTLS_EmptyCAIsRefused covers a bundle that reads but holds
+// nothing. client-go appends a CA file to an empty pool and keeps the pool
+// only if something was added, so zero bytes leave RootCAs nil and the
+// connection falls back to whatever the image trusts, which is wider than the
+// cluster CA and arrived at without saying so. A file that cannot be parsed
+// was already refused; this is the case between the two.
+func TestPorchStorageTLS_EmptyCAIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	empty := filepath.Join(dir, "empty-ca.crt")
+	require.NoError(t, os.WriteFile(empty, nil, 0o600))
+	usable := writeCAFile(t, newPorchTLSServer(t).Certificate())
+
+	// Not only zero bytes: whatever is installed has to parse, and the file
+	// has to be named, which client-go's own message does not do.
+	for name, content := range map[string]string{
+		"zero bytes":      "",
+		"whitespace only": "   \n\t ",
+		"not a PEM block": "not a certificate\n",
+		"a truncated PEM": "-----BEGIN CERTIFICATE-----\nnope\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			isolateClusterEnv(t)
+			bad := filepath.Join(t.TempDir(), "ca.crt")
+			require.NoError(t, os.WriteFile(bad, []byte(content), 0o600))
+			_, err := NewPorchStorage(&PorchStorageConfig{
+				KubernetesURL: "https://api.example:6443", Token: "t",
+				Namespace: "default", Repository: "focom-resources", CAFile: bad})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), bad)
+			assert.Contains(t, err.Error(), "holds no certificate")
+		})
+	}
+
+	t.Run("from the config", func(t *testing.T) {
+		isolateClusterEnv(t)
+		_, err := NewPorchStorage(&PorchStorageConfig{
+			KubernetesURL: "https://api.example:6443", Token: "t",
+			Namespace: "default", Repository: "focom-resources", CAFile: empty})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), empty)
+	})
+
+	t.Run("from the environment", func(t *testing.T) {
+		isolateClusterEnv(t)
+		t.Setenv("KUBERNETES_CA_FILE", empty)
+		_, err := NewPorchStorage(&PorchStorageConfig{
+			KubernetesURL: "https://api.example:6443", Token: "t",
+			Namespace: "default", Repository: "focom-resources"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), empty)
+	})
+
+	t.Run("mounted in the pod", func(t *testing.T) {
+		isolateClusterEnv(t)
+		withInClusterCA(t, empty)
+		t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+		t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+		_, err := NewPorchStorage(&PorchStorageConfig{
+			Token: "t", Namespace: "default", Repository: "focom-resources"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), empty)
+	})
+
+	t.Run("a usable bundle is untouched", func(t *testing.T) {
+		isolateClusterEnv(t)
+		_, err := NewPorchStorage(&PorchStorageConfig{
+			KubernetesURL: "https://api.example:6443", Token: "t",
+			Namespace: "default", Repository: "focom-resources", CAFile: usable})
+		require.NoError(t, err)
+	})
+
+	t.Run("no bundle keeps the system roots", func(t *testing.T) {
+		isolateClusterEnv(t)
+		_, err := NewPorchStorage(&PorchStorageConfig{
+			KubernetesURL: "https://other.example:6443", Token: "t",
+			Namespace: "default", Repository: "focom-resources"})
+		require.NoError(t, err)
+	})
+}
+
+// TestPorchStorageTLS_LeadingZeroPortStillNeedsTheClusterCA is the constructor
+// half of the origin comparison: ":0443" is the advertised endpoint however it
+// is spelled, so it has to ask for the same bundle.
+func TestPorchStorageTLS_LeadingZeroPortStillNeedsTheClusterCA(t *testing.T) {
+	isolateClusterEnv(t)
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL: "https://10.96.0.1:0443",
+		Token:         "test-token",
+		Namespace:     "default",
+		Repository:    "focom-resources",
+	})
+	require.Error(t, err)
+	assert.Nil(t, storage)
+	assert.Contains(t, err.Error(), inClusterCAFile)
+}
+
+// TestPorchStorageTLS_RequestPathSurvivesTheBaseURL covers the join. A base
+// URL ending in "/" produced "//apis", which the API server answers with a
+// redirect, and a proxy prefix has to survive.
+func TestPorchStorageTLS_RequestPathSurvivesTheBaseURL(t *testing.T) {
+	for _, suffix := range []string{"", "/", "/proxy", "/proxy/"} {
+		t.Run("base"+suffix, func(t *testing.T) {
+			var got string
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = r.URL.Path
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{"items": []interface{}{}})
+			}))
+			defer server.Close()
+
+			storage := &PorchStorage{
+				httpClient: server.Client(), kubernetesURL: server.URL + suffix,
+				namespace: "default", repository: "focom-resources"}
+			require.NoError(t, storage.HealthCheck(context.Background()))
+
+			want := strings.TrimSuffix(suffix, "/") +
+				"/apis/porch.kpt.dev/v1alpha1/namespaces/default/packagerevisions"
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+// TestPorchStorageTLS_UnusableEndpointIsRefusedBeforeTheCA checks the order.
+// Which bundle an address gets is a decision about an endpoint, so an endpoint
+// that cannot carry a token has to be refused first: the origin comparison
+// ignores everything but scheme, host and port, and would otherwise hand the
+// cluster CA to a plaintext address on its way to being rejected anyway.
+func TestPorchStorageTLS_UnusableEndpointIsRefusedBeforeTheCA(t *testing.T) {
+	isolateClusterEnv(t)
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+	withInClusterCA(t, writeCAFile(t, newPorchTLSServer(t).Certificate()))
+
+	restConfig, err := buildRESTConfig(&PorchStorageConfig{
+		KubernetesURL: "http://10.96.0.1:443",
+	})
+	require.Error(t, err)
+	assert.Nil(t, restConfig)
+	assert.Contains(t, err.Error(), "must use https")
+}
+
+func TestPorchStorageTLS_EquivalentClusterAddresses(t *testing.T) {
+	for _, kubernetesURL := range []string{
+		"https://10.96.0.1:443",
+		"https://10.96.0.1",
+		"https://kubernetes.default.svc",
+		"https://kubernetes.default.svc:443",
+		"https://KUBERNETES.DEFAULT.SVC",
+		"https://[::ffff:10.96.0.1]:443",
+	} {
+		t.Run(kubernetesURL, func(t *testing.T) {
+			isolateClusterEnv(t)
+			t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+			t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+			storage, err := NewPorchStorage(&PorchStorageConfig{
+				KubernetesURL: kubernetesURL,
+				Token:         "test-token",
+				Namespace:     "default",
+				Repository:    "focom-resources",
+			})
+			require.Error(t, err)
+			assert.Nil(t, storage)
+			assert.Contains(t, err.Error(), inClusterCAFile,
+				"should have chosen the cluster bundle for %s", kubernetesURL)
+		})
+	}
+}
+
+func TestPorchStorageTLS_PartialServiceEnvIsRefused(t *testing.T) {
+	isolateClusterEnv(t)
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		Token:      "test-token",
+		Namespace:  "default",
+		Repository: "focom-resources",
+	})
+	require.Error(t, err)
+	assert.Nil(t, storage)
+	assert.Contains(t, err.Error(), "must be set together")
+}
+
+// TestPorchStorageTLS_SkipVerifyOptIn checks the development escape hatch.
+func TestPorchStorageTLS_SkipVerifyOptIn(t *testing.T) {
+	isolateClusterEnv(t)
+	server := newPorchTLSServer(t)
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL:         server.URL,
+		Token:                 "test-token",
+		Namespace:             "default",
+		Repository:            "focom-resources",
+		InsecureSkipTLSVerify: true,
+	})
+	require.NoError(t, err)
+
+	assert.NoError(t, storage.HealthCheck(context.Background()))
 }
 
 // TEMPORARY TEST - TestHealthCheck_Success tests successful health check

--- a/operators/focom-operator/internal/nbi/testconfig.go
+++ b/operators/focom-operator/internal/nbi/testconfig.go
@@ -39,13 +39,16 @@ type StorageConfig struct {
 
 // PorchConfig holds Porch-specific configuration
 type PorchConfig struct {
-	UseKubeconfig bool   `yaml:"useKubeconfig,omitempty"` // Use kubeconfig for auth (handles exec, certs, etc.)
+	UseKubeconfig bool   `yaml:"useKubeconfig,omitempty"` // Use kubeconfig for auth (client certs; exec plugins are not yet honoured)
 	Kubeconfig    string `yaml:"kubeconfig,omitempty"`    // Path to kubeconfig (optional, auto-detected)
 	KubernetesURL string `yaml:"kubernetesURL,omitempty"` // Optional, auto-detected from KUBECONFIG
 	Token         string `yaml:"token,omitempty"`         // Optional, auto-detected
 	Namespace     string `yaml:"namespace"`
 	Repository    string `yaml:"repository"`
-	HTTPSVerify   bool   `yaml:"httpsVerify"`
+	CAFile        string `yaml:"caFile,omitempty"` // PEM bundle verifying the API server (optional)
+	// InsecureSkipTLSVerify skips verification of the API server certificate.
+	// Development only; the zero value verifies.
+	InsecureSkipTLSVerify bool `yaml:"insecureSkipTLSVerify,omitempty"`
 }
 
 // TestOptions holds test execution options
@@ -63,9 +66,8 @@ func DefaultTestConfig() *TestConfig {
 			Backend: "memory",
 		},
 		Porch: PorchConfig{
-			Namespace:   "default",
-			Repository:  "focom-resources",
-			HTTPSVerify: false,
+			Namespace:  "default",
+			Repository: "focom-resources",
 		},
 		Test: TestOptions{
 			Cleanup:        true,

--- a/operators/focom-operator/internal/nbi/testconfig.yaml.example
+++ b/operators/focom-operator/internal/nbi/testconfig.yaml.example
@@ -42,9 +42,14 @@ porch:
   
   # Porch repository name
   repository: focom-resources
-  
-  # Verify HTTPS certificates (set to true for production)
-  httpsVerify: false
+
+  # PEM bundle used to verify the API server certificate. Optional: in-cluster
+  # the service account CA is used, and a kubeconfig carries its own CA.
+  # caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+  # Skip verification of the API server certificate. Development only: the
+  # bearer token is then exposed to anyone able to intercept the connection.
+  # insecureSkipTLSVerify: false
 
 # Test execution options
 test:
@@ -74,8 +79,8 @@ test:
 # porch:
 #   namespace: default
 #   repository: focom-resources-test
-#   httpsVerify: false
-# # Token and kubernetesURL will be auto-detected from KUBECONFIG
+# # Only the token is taken from KUBECONFIG unless useKubeconfig: true is set;
+# # kubernetesURL and the CA are not. See the note on useKubeconfig above.
 
 # Example 3: CI/CD with Porch storage (use environment variables)
 # export NBI_STORAGE_BACKEND=porch

--- a/operators/focom-operator/kpt-package/focom-operator-bundle.yaml
+++ b/operators/focom-operator/kpt-package/focom-operator-bundle.yaml
@@ -667,10 +667,6 @@ spec:
           value: default
         - name: PORCH_REPOSITORY
           value: focom-resources
-        - name: KUBERNETES_BASE_URL
-          value: https://kubernetes.default.svc
-        - name: PORCH_HTTPS_VERIFY
-          value: "false"
         image: docker.io/nephio/focom-operator:latest
         imagePullPolicy: Always
         livenessProbe:


### PR DESCRIPTION
The FOCOM NBI Porch client decides whether to verify the Kubernetes API server certificate from `os.Getenv("PORCH_HTTPS_VERIFY") == "true"`, and `newPorchStorageWithToken` feeds the negation of that into `tls.Config.InsecureSkipVerify`. Anything that is not the exact string `true` leaves verification off, the variable being unset included. Both shipped manifests set it to `"false"`, so a deployment built from `config/` or from the kpt package attaches its service account bearer token to every Porch request over a connection whose peer was never authenticated. CWE-295.

This makes verification the default, moves the TLS setup onto client-go, and renames the opt-out so it cannot be reached by omission.

## The bundle was already mounted

The Kubernetes documentation on [accessing the API from a Pod](https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/):

> If available, a certificate bundle is placed into the filesystem tree of each container at `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`, and should be used to verify the serving certificate of the API server.

That bundle is already mounted in the FOCOM pod. It was never read, while the token sitting next to it was attached to every request by `makeRequest`. `cmd/main.go` grants that service account `create;delete;get;list;patch;update;watch` on `porch.kpt.dev` packagerevisions and `get;list;watch` on secrets, which is what the token is worth to whoever intercepts it: read what the operator reads, and rewrite the package revisions GitOps then applies to the cluster.

The same page also says which address the certificate is good for:

> Kubernetes does not guarantee that the API server has a valid certificate for the hostname `kubernetes.default.svc`; however, the control plane **is** expected to present a valid certificate for the hostname or IP address that `$KUBERNETES_SERVICE_HOST` represents.

Both manifests pinned `KUBERNETES_BASE_URL=https://kubernetes.default.svc`, which is the address without the guarantee. Turning verification on while keeping that value would trade a silent failure for a noisy one on any cluster whose serving certificate lacks that SAN, so the variable goes from the manifests and the address comes from `KUBERNETES_SERVICE_HOST`/`PORT` in a pod. It stays available as an override for anyone reaching the API through a proxy.

Unlike the o2ims operator, nothing in another repository has to be published in step with this one.

An installed Deployment is a different question, and I had this wrong. Editing the manifests in git does not edit a cluster. A deployment applied before this still carries

```
KUBERNETES_BASE_URL=https://kubernetes.default.svc
PORCH_HTTPS_VERIFY=false
```

and if the image is upgraded without re-applying the package, that explicit URL still wins over the address the pod is told about. `PORCH_HTTPS_VERIFY` goes inert either way, so verification does turn on, but against the address without the SAN guarantee. A fresh install needs no configuration; an upgrade of an existing one needs those two variables removed. Anyone who set `KUBERNETES_BASE_URL` deliberately, to reach the API through a proxy, keeps it and supplies that endpoint's CA.

## What the client looks like now

The hand-built `http.Transport` is gone and connection settings come from a `rest.Config`. `rest.HTTPClientFor` turns that into the HTTP client, which is the path `newPorchStorageFromKubeconfig` already used, so the two constructors now differ only in where their credentials come from. Outside a cluster a CA bundle can be supplied through `KUBERNETES_CA_FILE` or `PorchStorageConfig.CAFile`, and an unreadable bundle fails at construction rather than degrading to an unverified connection.

Host and CA are read from the environment rather than through `rest.InClusterConfig`. That function reads the fixed service account token before it will return either, so a pod running with `automountServiceAccountToken: false` and its token projected somewhere else, which Kubernetes supports, supplied everything needed and was still refused. Reading the two variables directly also removes the earlier choice between swallowing every `InClusterConfig` error and failing on one that never mattered: half a service environment is a configuration error, and the in-pod CA requirement is enforced on its own.

The bundle follows the address rather than the pod:

```go
	origin := apiServerOrigin(restConfig.Host)
	if caFile == "" && inClusterHost != "" &&
		(origin == apiServerOrigin(inClusterHost) ||
			origin == apiServerOrigin(defaultKubernetesURL)) {
		caFile = inClusterCAFile // required, not best effort
	}
```

The first draft applied the cluster CA whenever `KUBERNETES_SERVICE_HOST` was set. An operator in a pod pointed at some other Porch endpoint then had the cluster CA pinned to a server that CA does not certify, and every connection to it would fail. The cluster serves its API at the advertised address and at `https://kubernetes.default.svc`; anything else keeps the system roots, so the certificate is still checked, against the right authorities.

That comparison is by endpoint and not by string. `https://10.96.0.1` and `https://10.96.0.1:443` are one endpoint with one certificate, as are the short and long spellings of an IPv6 address and any casing of a DNS name. Comparing URLs as written sent four such forms to the system roots:

```console
https://10.96.0.1:443                  -> cluster CA
https://10.96.0.1                      -> public roots
https://kubernetes.default.svc         -> cluster CA
https://kubernetes.default.svc:443     -> public roots
```

That fails closed on a private-CA cluster rather than weakening anything, but it fails a configuration that is correct. `apiServerOrigin` normalises scheme, host and effective port first.

Fuzzing the validator against what the transport actually dials turned up one class `url.Parse` does not cover. It refuses a percent escape in the host, but keeps a non-ASCII name as written, and `net/http` maps it before dialling:

```console
"https://ⓔxample.com"    parsed host "ⓔxample.com"
                         dialled     "example.com"
```

So an operator can name one host, have its origin computed from that name, and reach another. The host has to be a shape every parser reads the same way now: an IP literal, or a DNS name of letter-digit-hyphen labels. Of two hundred thousand random authorities drawn from an alphabet of separators, escapes and full-width lookalikes, seventeen hundred are accepted and every one parses to a host already in that shape, which is the shape `idna.ToASCII` leaves alone. Port zero is refused too, since `url.Parse` only checks that a port is digits. o2ims arrived at the same rule in #1170, and the two now return the same verdict for every address in a shared corpus of twenty, valid and hostile alike.

Three other paths that could have broken the invariant were closed after review. The endpoint must parse as an absolute `https` URL with a host and no embedded credentials, because a plaintext `KUBERNETES_BASE_URL` used to be accepted verbatim with `makeRequest` sending the token over it and no opt-out required; the skip flag deliberately does not make plaintext legal. In a pod with no readable CA the connection fell back to the system roots, which is a wider trust boundary rather than a failure, so that now refuses to start unless a bundle is supplied or verification is explicitly skipped. And a CA bundle combined with the skip flag is refused rather than quietly discarded, with the flag clearing only the bundle instead of the whole TLS config, so `ServerName` and client certificates survive it.

The opt-out is `UNSAFE_SKIP_TLS_VERIFY`, parsed with `strconv.ParseBool` so a typo cannot relax it, and logged at startup when engaged. It is named for what it does rather than as a reversed `_VERIFY` flag, because a flag that disables verification by being absent is how this default became insecure. `PORCH_HTTPS_VERIFY` is not read at all any more; honouring it would preserve exactly the value the manifests encode. Startup says so if it is still set.

## Proof manifests

The rendered deployment is the easiest place to see it. On `main`, `kustomize build config/default` ships the insecure setting as a literal:

```console
        - name: PORCH_REPOSITORY
          value: focom-resources
        - name: KUBERNETES_BASE_URL
          value: https://kubernetes.default.svc
        - name: PORCH_HTTPS_VERIFY
          value: "false"
```

With this PR neither variable is rendered at all, so nothing has to opt back into verification:

```console
        - name: PORCH_REPOSITORY
          value: focom-resources
        image: docker.io/nephio/focom-operator:latest
```

Twenty one tests cover the boundary, against an `httptest.NewTLSServer` whose certificate no trust store knows about, the way a cluster CA is unknown to one:

```console
$ go test ./internal/nbi/storage/ -run TestPorchStorageTLS -v
--- PASS: TestPorchStorageTLS_VerifiedByDefault
--- PASS: TestPorchStorageTLS_TrustsConfiguredCA
--- PASS: TestPorchStorageTLS_CAFileFromEnv
--- PASS: TestPorchStorageTLS_UnreadableCAFile
--- PASS: TestPorchStorageTLS_RejectsPlainHTTP
--- PASS: TestPorchStorageTLS_RejectsUnusableURL
--- PASS: TestPorchStorageTLS_RejectsCAWithSkipVerify
--- PASS: TestPorchStorageTLS_CustomTokenInPod
--- PASS: TestPorchStorageTLS_InPodWithoutCAFailsClosed
--- PASS: TestPorchStorageTLS_InPodWithMalformedCAFailsClosed
--- PASS: TestPorchStorageTLS_OtherEndpointKeepsSystemRoots
--- PASS: TestPorchStorageTLS_ClusterNameUsesClusterCA
--- PASS: TestPorchStorageTLS_UnusableHostsAreRefused
--- PASS: TestPorchStorageTLS_APIServerOrigin
--- PASS: TestPorchStorageTLS_EmptyCAIsRefused
--- PASS: TestPorchStorageTLS_LeadingZeroPortStillNeedsTheClusterCA
--- PASS: TestPorchStorageTLS_RequestPathSurvivesTheBaseURL
--- PASS: TestPorchStorageTLS_UnusableEndpointIsRefusedBeforeTheCA
--- PASS: TestPorchStorageTLS_EquivalentClusterAddresses
--- PASS: TestPorchStorageTLS_PartialServiceEnvIsRefused
--- PASS: TestPorchStorageTLS_SkipVerifyOptIn
ok      github.com/nephio-project/nephio/operators/focom-operator/internal/nbi/storage
```

A passing test proves little on its own, so each one was run against the change it is supposed to catch. Reverting the secure default fails `VerifiedByDefault` and `UnreadableCAFile`. Removing the https check fails `RejectsPlainHTTP`. Removing the in-pod CA requirement fails `InPodWithoutCAFailsClosed`. Removing the partial-environment check fails `PartialServiceEnvIsRefused`. Unscoping the cluster CA fails `OtherEndpointKeepsSystemRoots`, and dropping the in-cluster name from that rule fails `ClusterNameUsesClusterCA`.

The suite also has to give the same answer wherever it runs. `TestMain` clears the variables the kubelet injects, because this code reads them now. Without it, running the package inside a pod picks up whichever cluster that is, and four pre-existing tests about token and kubeconfig resolution fail on a CA bundle they were never about:

```console
$ env KUBERNETES_SERVICE_HOST=10.96.0.1 KUBERNETES_SERVICE_PORT=443 \
      go test -count=1 -shuffle=on ./internal/nbi/storage/     # before TestMain
--- FAIL: TestNewPorchStorage_WithConfig
    open /var/run/secrets/kubernetes.io/serviceaccount/ca.crt: no such file or directory
... 6 failures

$ env KUBERNETES_SERVICE_HOST=10.96.0.1 KUBERNETES_SERVICE_PORT=443 \
      go test -count=1 -shuffle=on ./internal/nbi/storage/     # after
ok      github.com/nephio-project/nephio/operators/focom-operator/internal/nbi/storage
```

The two in-pod cases used to depend on the machine running them. `inClusterCAFile` was a constant, so a test could not hide the bundle Kubernetes mounts at that path in any pod carrying the service account credential, a presubmit pod included. Making it a variable that tests redirect fixes that, and with a bundle placed at the real path the difference shows:

```console
$ sudo cp /etc/ssl/certs/ca-certificates.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
$ go test ./internal/nbi/storage/ -run 'TestPorchStorageTLS_InPod'      # with the fix
ok

$ # with the test unable to redirect the path, as before
--- FAIL: TestPorchStorageTLS_InPodWithoutCAFailsClosed
```

It also makes a malformed bundle at the fixed path testable for the first time, which an earlier revision of this description listed as out of reach.

None of that means anything unless CI runs it. `presubmit-nephio-go-test` runs `make unit`, whose storage step carries a `-run` allowlist, so a new test is invisible to CI unless it is named there. The shared `TestPorchStorageTLS` prefix is added to the allowlist, which covers future tests in the group without touching the Makefile again:

```console
$ make unit | grep -c '^=== RUN'
231                    # 186 before this change

$ make gosec
  Files  : 51
  Issues : 0

$ go test ./internal/... -count=1
ok      .../internal/controller           0.129s
ok      .../internal/nbi                  0.039s
ok      .../internal/nbi/models           0.020s
ok      .../internal/nbi/services         0.027s
ok      .../internal/nbi/storage          6.406s
ok      .../internal/nbi/validation       0.038s
```

`gosec` also needs one fewer `#nosec` to stay clean, since `G402` was suppressed at the line this deletes. `test/e2e` is not in that list because it fails identically on `main` here; it needs a live cluster and network access to install the Prometheus operator.

## One behaviour change worth knowing about

client-go installs `http.ProxyFromEnvironment` and the transport it replaces set no proxy at all. Measured rather than reasoned about:

```console
main (hand-built transport)   proxy not contacted
this branch (HTTPClientFor)   proxy CONTACTED: "CONNECT 10.96.0.1:443 HTTP/1.1"
```

So on a cluster that exports `HTTPS_PROXY` to workloads with no `NO_PROXY` entry for the API server, this connection starts going through it. Two things make that acceptable rather than a regression. The manager's own client in the same binary has always gone through client-go and therefore always honoured those variables, so this makes the Porch client consistent rather than novel. And pinning the cluster CA means a proxy that terminates TLS fails the handshake instead of quietly reading the token. `docs/PORCH_SETUP.md` says so now.

## Effect on existing deployments

In-cluster deployments need no configuration, since the CA bundle and the API address both come from the pod. Anyone running the operator outside a cluster against an endpoint named by `KUBERNETES_BASE_URL` now needs `KUBERNETES_CA_FILE`, or `useKubeconfig`, which carries its cluster CA already. `PORCH_HTTPS_VERIFY` becomes inert, and `UNSAFE_SKIP_TLS_VERIFY=true` restores the old behaviour for development, loudly. `PorchStorageConfig.HTTPSVerify` is replaced by `InsecureSkipTLSVerify` and `CAFile` so the zero value is the safe one, with `internal/nbi/testconfig.go` and its example following.

## Left out on purpose

Most of the storage package is outside the `make unit` allowlist, so it never runs in CI either. Widening that is a separate question, since some of those tests read `KUBECONFIG` and the ambient environment, which is presumably why the list exists at all.

`makeRequest` still sets the `Authorization` header by hand from a token read once at startup, so client-go's `BearerTokenFile` refresh goes unused and a rotated projected token will eventually 401, and an empty `Bearer ` suppresses exec auth under a kubeconfig. That is #1171. The fix is to put credentials on the `rest.Config` and reuse the manager's config instead of rediscovering one, and it reaches around thirty test constructions that build `PorchStorage` directly with a token field, which is why it is not here. The documentation claiming kubeconfig exec support has been corrected in this PR rather than left standing.

The o2ims operator had the same shape with a worse outcome, `bool(os.getenv("HTTPS_VERIFY", False))` being `False` when unset and `True` when set to the string `"false"`. That went in as #1170.

## Notes for maintainers

`operators/focom-operator/docs/{PORCH_SETUP,DEPLOYMENT}.md` are updated here. I searched nephio-project/docs for `PORCH_HTTPS_VERIFY`, `HTTPS_VERIFY` and the FOCOM install guide and found no reference to these variables, so a companion PR there does not look necessary. Happy to raise one if you disagree.

Release triage is yours to set. The change is confined to the FOCOM operator's Porch client and its manifests.

`SECURITY.md` asks that vulnerabilities not be reported through public issues, and I have not opened one. Say the word and I will route this through sig-security@lists.nephio.org before it goes further.

