### PR TITLE
[security][o2ims] Verify Kubernetes API TLS certificates by default

### DIFF
--- a/operators/o2ims-operator/README.md
+++ b/operators/o2ims-operator/README.md
@@ -105,6 +105,49 @@ kpt live init /tmp/o2ims
 kpt live apply /tmp/o2ims --reconcile-timeout=15m --output=table
 ```
 
+### Connecting to the Kubernetes API
+
+The operator verifies the API server's certificate on every request. Inside a
+pod there is nothing to configure: the CA bundle mounted at
+`/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` is used, and the address
+comes from `KUBERNETES_SERVICE_HOST`, which is the one Kubernetes expects that
+certificate to be valid for.
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `KUBERNETES_BASE_URL` | in-cluster address | API server to talk to |
+| `KUBERNETES_CA_FILE` | in-cluster CA bundle | PEM bundle used to verify the API server |
+| `UNSAFE_SKIP_TLS_VERIFY` | `false` | Development only: skip certificate verification |
+
+Running the operator outside a cluster, point it at the API server and at the
+CA that signs its certificate:
+
+```bash
+export KUBERNETES_BASE_URL=$(kubectl config view --minify \
+  -o jsonpath='{.clusters[0].cluster.server}')
+
+# The CA is embedded in most kubeconfigs and a file path in some.
+kubectl config view --raw --minify \
+  -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' \
+  | base64 -d > /tmp/cluster-ca.crt
+test -s /tmp/cluster-ca.crt || cp "$(kubectl config view --minify \
+  -o jsonpath='{.clusters[0].cluster.certificate-authority}')" /tmp/cluster-ca.crt
+export KUBERNETES_CA_FILE=/tmp/cluster-ca.crt
+
+# TOKEN is a path, not a token. Outside a pod there is no mounted one, so
+# request a short-lived credential and point at the file.
+kubectl -n o2ims create token o2ims-operator --duration=1h > /tmp/o2ims-token
+chmod 0600 /tmp/o2ims-token
+export TOKEN=/tmp/o2ims-token
+```
+
+The token expires; re-run the last three lines when it does. Inside a pod
+none of this applies, because the kubelet rotates the mounted one.
+
+`UNSAFE_SKIP_TLS_VERIFY=true` turns verification off altogether. It hands the
+service account token to an endpoint whose identity has not been checked, warns
+about it at startup, and must never be used outside development.
+
 ### Redeploying
 
 To redeploy the cluster, or to recreate the development environment, one must delete the created cluster. The Nephio mgmt cluster will be deleted automatically when running `create-cluster.sh`, but the cluster deployed by this operator has a name in the `clusterName` field. For example, it may be `edge`, thus:

--- a/operators/o2ims-operator/controllers/utils.py
+++ b/operators/o2ims-operator/controllers/utils.py
@@ -14,11 +14,12 @@
 # limitations under the License.
 ##########################################################################
 
+import logging
 import os
+import ssl
+from urllib.parse import urlsplit
 
 import requests
-
-requests.packages.urllib3.disable_warnings()
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 # Allowed values vanilla/Openshift
@@ -27,12 +28,130 @@ KUBERNETES_TYPE = str(os.getenv("KUBERNETES_TYPE", "vanilla")).lower()
 LABEL = {"owner": "o2ims.provisioning.oran.org.provisioningrequests"}
 # Log level of the controller
 LOG_LEVEL = str(os.getenv("LOG_LEVEL", "DEBUG"))
-# To verify HTTPs certificates when communicating with cluster
-HTTPS_VERIFY = bool(os.getenv("HTTPS_VERIFY", False))
+
+LOGGER = logging.getLogger(__name__)
+
+# CA bundle Kubernetes mounts into every container
+IN_CLUSTER_CA_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+# API server address used outside a cluster
+DEFAULT_KUBERNETES_BASE_URL = "https://kubernetes.default.svc"
+
+
+def env_flag(name: str) -> bool:
+    """Return True only for an explicit true value; anything else is False."""
+    return os.getenv(name, "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def validate_api_server_url(base_url: str) -> str:
+    """Return base_url once it is safe to send a bearer token to.
+
+    requests applies ``verify`` only to https, so a plaintext endpoint is
+    refused outright rather than merely unverified.
+
+    :return: the url, without a trailing slash
+    :rtype: str
+    """
+    parsed = urlsplit(base_url)
+    try:
+        parsed.port
+        problem = ""
+        if parsed.scheme != "https":
+            problem = "must use https"
+        elif not parsed.hostname:
+            problem = "has no host"
+        elif parsed.username or parsed.password:
+            problem = "must not embed credentials"
+        elif parsed.query or parsed.fragment:
+            problem = "must not carry a query or fragment"
+    except ValueError:
+        problem = "has an invalid port"
+    if problem:
+        raise RuntimeError(f"Kubernetes API url {base_url!r} {problem}")
+    return base_url.rstrip("/")
+
+
+def validate_ca_bundle(path: str) -> str:
+    """Return path once it actually loads as a CA bundle.
+
+    Checking the path alone would accept an empty or malformed PEM and
+    defer the failure to the first request.
+
+    :return: the path
+    :rtype: str
+    """
+    try:
+        ssl.create_default_context(cafile=path)
+    except (OSError, ssl.SSLError) as exc:
+        raise RuntimeError(f"CA bundle {path!r} is unusable: {exc}") from exc
+    return path
+
+
+def kubernetes_base_url() -> str:
+    """
+    :return: KUBERNETES_BASE_URL, else the address advertised to the pod,
+             the only one its certificate is expected to be valid for
+    :rtype: str
+    """
+    base_url = os.getenv("KUBERNETES_BASE_URL")
+    if base_url:
+        return validate_api_server_url(base_url)
+    host = os.getenv("KUBERNETES_SERVICE_HOST")
+    if not host:
+        return DEFAULT_KUBERNETES_BASE_URL
+    if ":" in host and not host.startswith("["):  # IPv6 literal
+        host = f"[{host}]"
+    port = os.getenv("KUBERNETES_SERVICE_PORT", "443")
+    return validate_api_server_url(f"https://{host}:{port}")
+
+
+def tls_verify():
+    """
+    Only UNSAFE_SKIP_TLS_VERIFY disables verification; the bearer token
+    below is attached to every request. In a pod the mounted CA has to
+    load, because the fallback is not a failed handshake but the public
+    roots requests ships with.
+
+    :return: CA bundle path, True for the requests default bundle, or False
+    :rtype: str or bool
+    """
+    unsafe = env_flag("UNSAFE_SKIP_TLS_VERIFY")
+    ca_file = os.getenv("KUBERNETES_CA_FILE")
+    if unsafe and ca_file:
+        raise RuntimeError(
+            "KUBERNETES_CA_FILE and UNSAFE_SKIP_TLS_VERIFY conflict, "
+            "refusing to guess which one was meant"
+        )
+    if unsafe:
+        return False
+    if ca_file:
+        return validate_ca_bundle(ca_file)
+    if os.path.exists(IN_CLUSTER_CA_FILE):
+        return validate_ca_bundle(IN_CLUSTER_CA_FILE)
+    if os.getenv("KUBERNETES_SERVICE_HOST"):
+        raise RuntimeError(
+            f"the in-cluster CA {IN_CLUSTER_CA_FILE} is missing; supply "
+            "KUBERNETES_CA_FILE or set UNSAFE_SKIP_TLS_VERIFY"
+        )
+    return True
+
+
+# Verify the API server certificate on every request
+TLS_VERIFY = tls_verify()
+if TLS_VERIFY is False:
+    LOGGER.warning(
+        "UNSAFE_SKIP_TLS_VERIFY is set: the Kubernetes API server "
+        "certificate will NOT be verified and the service account token "
+        "can be intercepted. Never enable this outside development."
+    )
+if os.getenv("HTTPS_VERIFY") is not None:
+    LOGGER.warning(
+        "HTTPS_VERIFY is no longer supported and is ignored; certificates "
+        "are always verified unless UNSAFE_SKIP_TLS_VERIFY=true"
+    )
 # Token used to communicate with Kube cluster
 TOKEN = os.getenv("TOKEN", "/var/run/secrets/kubernetes.io/serviceaccount/token")
 TOKEN = os.popen(f"cat {TOKEN}").read()
-KUBERNETES_BASE_URL = str(os.getenv("KUBERNETES_BASE_URL", "http://127.0.0.1:8080"))
+KUBERNETES_BASE_URL = kubernetes_base_url()
 UPSTREAM_PKG_REPO = os.getenv("UPSTREAM_PKG_REPO", "catalog-infra-capi")
 
 HEADERS_DICT = {
@@ -97,7 +216,7 @@ def create_package_variant(
             f"{KUBERNETES_BASE_URL}/apis/config.porch.kpt.dev/v1alpha1/namespaces/{namespace}/packagevariants",
             headers=HEADERS_DICT,
             json=pv_body,
-            verify=HTTPS_VERIFY,
+            verify=TLS_VERIFY,
         )
         if logger:
             logger.debug(
@@ -142,7 +261,7 @@ def get_package_variant(name: str = None, namespace: str = None, logger=None):
         r = requests.get(
             f"{KUBERNETES_BASE_URL}/apis/config.porch.kpt.dev/v1alpha1/namespaces/{namespace}/packagevariants/{name}",
             headers=HEADERS_DICT,
-            verify=HTTPS_VERIFY,
+            verify=TLS_VERIFY,
         )
     except Exception as e:
         if logger:
@@ -188,7 +307,7 @@ def check_o2ims_provisioning_request(
         r = requests.get(
             f"{KUBERNETES_BASE_URL}/apis/o2ims.provisioning.oran.org/v1alpha1/provisioningrequests",
             headers=HEADERS_DICT,
-            verify=HTTPS_VERIFY,
+            verify=TLS_VERIFY,
         )
     except Exception as e:
         if logger:
@@ -249,7 +368,7 @@ def get_capi_cluster(name: str = None, namespace: str = None, logger=None):
         r = requests.get(
             f"{KUBERNETES_BASE_URL}/apis/cluster.x-k8s.io/v1beta1/namespaces/{namespace}/clusters/{name}",
             headers=HEADERS_DICT,
-            verify=HTTPS_VERIFY,
+            verify=TLS_VERIFY,
         )
     except Exception as e:
         if logger:

--- a/operators/o2ims-operator/tests/deployment/operator.yaml
+++ b/operators/o2ims-operator/tests/deployment/operator.yaml
@@ -101,8 +101,6 @@ spec:
         env:
           - name: 'UPSTREAM_PKG_REPO'
             value: 'catalog-infra-capi'
-          - name: 'KUBERNETES_BASE_URL'
-            value: 'https://kubernetes.default.svc'
         resources:
           requests:
             memory: "256Mi"

--- a/operators/o2ims-operator/tests/test_utils.py
+++ b/operators/o2ims-operator/tests/test_utils.py
@@ -14,12 +14,17 @@
 # limitations under the License.
 ##########################################################################
 
-import responses
+import http.server
 import os
-import pytest
 import random
 import string
+import threading
 
+import certifi
+import pytest
+import responses
+
+from controllers import utils
 from controllers.utils import (
     KUBERNETES_BASE_URL,
     create_package_variant,
@@ -268,3 +273,186 @@ def test_get_capi_cluster(http_code, status, response_2, response_2_value, excep
         )
     response = get_capi_cluster(NAME, NAMESPACE)
     assert response["status"] == status and response[response_2] == response_2_value
+
+
+@pytest.fixture
+def no_ambient_tls_config(monkeypatch, tmp_path):
+    """Make the tests behave the same on a laptop and inside a pod."""
+    monkeypatch.setattr(
+        utils, "IN_CLUSTER_CA_FILE", str(tmp_path / "absent-ca.crt")
+    )
+    monkeypatch.delenv("KUBERNETES_CA_FILE", raising=False)
+    monkeypatch.delenv("UNSAFE_SKIP_TLS_VERIFY", raising=False)
+
+
+def test_tls_is_verified_by_default(no_ambient_tls_config):
+    # True is what requests calls "verify against the system trust store"
+    assert utils.tls_verify() is True
+
+
+def usable_ca_bundle(tmp_path, name):
+    """Return a path holding a bundle OpenSSL will actually load."""
+    bundle = tmp_path / name
+    bundle.write_bytes(open(certifi.where(), "rb").read())
+    return str(bundle)
+
+
+def test_in_cluster_ca_bundle_is_used_when_present(
+    no_ambient_tls_config, monkeypatch, tmp_path
+):
+    ca_file = usable_ca_bundle(tmp_path, "ca.crt")
+    monkeypatch.setattr(utils, "IN_CLUSTER_CA_FILE", ca_file)
+    assert utils.tls_verify() == ca_file
+
+
+def test_kubernetes_ca_file_wins(no_ambient_tls_config, monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        utils, "IN_CLUSTER_CA_FILE", usable_ca_bundle(tmp_path, "in-cluster.crt"))
+    configured = usable_ca_bundle(tmp_path, "configured.crt")
+    monkeypatch.setenv("KUBERNETES_CA_FILE", configured)
+    assert utils.tls_verify() == configured
+
+
+def test_a_missing_ca_file_is_refused(no_ambient_tls_config, monkeypatch, tmp_path):
+    missing = str(tmp_path / "missing.crt")
+    monkeypatch.setenv("KUBERNETES_CA_FILE", missing)
+    with pytest.raises(RuntimeError, match=missing):
+        utils.tls_verify()
+
+
+@pytest.mark.parametrize("content", ["", "   ", "not a pem\n", "-----BEGIN-----"])
+def test_an_unusable_ca_bundle_is_refused(
+    no_ambient_tls_config, monkeypatch, tmp_path, content
+):
+    """A path check alone would defer this to the first request."""
+    bundle = tmp_path / "ca.crt"
+    bundle.write_text(content)
+    monkeypatch.setenv("KUBERNETES_CA_FILE", str(bundle))
+    with pytest.raises(RuntimeError, match="unusable"):
+        utils.tls_verify()
+
+
+def test_a_ca_bundle_and_skip_verify_together_are_refused(
+    no_ambient_tls_config, monkeypatch, tmp_path
+):
+    monkeypatch.setenv("KUBERNETES_CA_FILE", usable_ca_bundle(tmp_path, "ca.crt"))
+    monkeypatch.setenv("UNSAFE_SKIP_TLS_VERIFY", "true")
+    with pytest.raises(RuntimeError, match="conflict"):
+        utils.tls_verify()
+
+
+def test_a_missing_in_cluster_ca_is_refused(
+    no_ambient_tls_config, monkeypatch, tmp_path
+):
+    """In a pod, an absent CA must not fall back to the public roots."""
+    monkeypatch.setattr(utils, "IN_CLUSTER_CA_FILE", str(tmp_path / "absent.crt"))
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+    with pytest.raises(RuntimeError, match="in-cluster CA"):
+        utils.tls_verify()
+
+
+def test_a_plaintext_endpoint_is_rejected_and_never_contacted(monkeypatch):
+    """requests ignores verify for http, so the token would go out in clear."""
+    contacted = []
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            contacted.append(self.headers.get("Authorization"))
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, *args):
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        monkeypatch.setenv(
+            "KUBERNETES_BASE_URL", f"http://127.0.0.1:{server.server_address[1]}")
+        with pytest.raises(RuntimeError, match="must use https"):
+            utils.kubernetes_base_url()
+    finally:
+        server.shutdown()
+
+    assert contacted == []
+
+
+@pytest.mark.parametrize("base_url", [
+    "kubernetes.default.svc",
+    "https://",
+    "https://user:pass@api.example.com:6443",
+    "https://api.example.com:6443?token=x",
+    "https://api.example.com:6443#f",
+    "https://api.example.com:not-a-port",
+])
+def test_an_unusable_endpoint_is_rejected(monkeypatch, base_url):
+    monkeypatch.setenv("KUBERNETES_BASE_URL", base_url)
+    with pytest.raises(RuntimeError):
+        utils.kubernetes_base_url()
+
+
+def test_a_trailing_slash_is_normalised(monkeypatch):
+    monkeypatch.setenv("KUBERNETES_BASE_URL", "https://api.example.com:6443/")
+    assert utils.kubernetes_base_url() == "https://api.example.com:6443"
+
+
+@pytest.mark.parametrize(
+    "value, verification_skipped",
+    [
+        ("true", True),
+        ("True", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+        ("false", False),
+        ("False", False),
+        ("0", False),
+        ("no", False),
+        ("", False),
+        ("  ", False),
+        ("maybe", False),
+    ],
+)
+def test_only_an_explicit_opt_in_skips_verification(
+    no_ambient_tls_config, monkeypatch, value, verification_skipped
+):
+    monkeypatch.setenv("UNSAFE_SKIP_TLS_VERIFY", value)
+    assert (utils.tls_verify() is False) == verification_skipped
+
+
+@responses.activate
+@pytest.mark.parametrize("verify", [True, "/etc/ssl/certs/test-ca.crt"])
+def test_requests_carry_the_verify_setting(monkeypatch, verify):
+    monkeypatch.setattr(utils, "TLS_VERIFY", verify)
+    responses.get(CAPI_URI, json=TEST_JSON, status=200)
+    get_capi_cluster(NAME, NAMESPACE)
+    assert responses.calls[0].request.req_kwargs["verify"] == verify
+
+
+@pytest.mark.parametrize(
+    "environment, expected",
+    [
+        (
+            {"KUBERNETES_BASE_URL": "https://api.example.com:6443"},
+            "https://api.example.com:6443",
+        ),
+        (
+            {"KUBERNETES_SERVICE_HOST": "10.96.0.1",
+             "KUBERNETES_SERVICE_PORT": "443"},
+            "https://10.96.0.1:443",
+        ),
+        ({"KUBERNETES_SERVICE_HOST": "fd00::1"}, "https://[fd00::1]:443"),
+        ({"KUBERNETES_SERVICE_HOST": "[fd00::1]"}, "https://[fd00::1]:443"),
+        ({}, "https://kubernetes.default.svc"),
+    ],
+)
+def test_kubernetes_base_url(monkeypatch, environment, expected):
+    for name in (
+        "KUBERNETES_BASE_URL",
+        "KUBERNETES_SERVICE_HOST",
+        "KUBERNETES_SERVICE_PORT",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    for name, value in environment.items():
+        monkeypatch.setenv(name, value)
+    assert utils.kubernetes_base_url() == expected


### PR DESCRIPTION
Sibling of #1168, which fixes the same class of defect in the FOCOM operator. This one is worse, because the flag involved cannot be used correctly at all.

`controllers/utils.py` passes `HTTPS_VERIFY` as the `verify` argument of every request it makes to the Kubernetes API, and computes it as:

```python
HTTPS_VERIFY = bool(os.getenv("HTTPS_VERIFY", False))
```

`os.getenv` returns the default `False` when the variable is unset, and a string when it is set. `bool()` of any non-empty string is `True`. The result:

```console
$ python3 -c '...'
HTTPS_VERIFY=None       -> verify=False
HTTPS_VERIFY='false'    -> verify=True
HTTPS_VERIFY='False'    -> verify=True
HTTPS_VERIFY='0'        -> verify=True
HTTPS_VERIFY='true'     -> verify=True
HTTPS_VERIFY=''         -> verify=False
HTTPS_VERIFY='no'       -> verify=True
```

Verification is off by default, and every spelling of "no" turns it *on*. The only two ways to disable it are to leave the variable alone and to set it to the empty string, so the flag has never done what its name says.

### What that costs

Neither `tests/deployment/operator.yaml` nor [the deployment in nephio-project/catalog](https://github.com/nephio-project/catalog/blob/main/nephio/optional/o2ims/app/deployment.yaml) sets `HTTPS_VERIFY`, and both point the operator at `https://kubernetes.default.svc`. Every request therefore completes a TLS handshake with a peer nobody authenticated, carrying this header:

```python
HEADERS_DICT = {
    ...
    "Authorization": "Bearer {}".format(TOKEN),
}
```

The token is the operator's, and `tests/deployment/operator.yaml` binds its service account to a ClusterRole holding `create, patch` on `validatingwebhookconfigurations` and `mutatingwebhookconfigurations`, plus `create, update, patch` on `customresourcedefinitions` and full write access to `cluster.x-k8s.io` clusters. An attacker who intercepts that token does not merely read the operator's resources; they can register a mutating admission webhook and rewrite objects across the entire cluster. CWE-295 leading to CWE-522.

The one signal that would have surfaced this was switched off two lines above the flag:

```python
requests.packages.urllib3.disable_warnings()
```

That call suppresses `InsecureRequestWarning`, which urllib3 emits precisely when `verify=False`.

### What replaces it

Quoting the Kubernetes documentation on [accessing the API from a Pod](https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/):

> If available, a certificate bundle is placed into the filesystem tree of each container at `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`, and should be used to verify the serving certificate of the API server.

So `tls_verify()` returns what `requests` actually wants for `verify`: that bundle when it is present, a bundle named by `KUBERNETES_CA_FILE` when one is configured, and `True` otherwise. Verification is skipped only for `UNSAFE_SKIP_TLS_VERIFY`, which is named for what it does, parsed so that anything unrecognised is false, and logged loudly when engaged. `HTTPS_VERIFY` is no longer read at all — none of its old values map onto a behaviour worth preserving — and startup says so if it is still set. `disable_warnings()` is gone.

Review closed four more paths through this, and one of them was in my own tests:

- **Plaintext was still accepted.** `requests` applies `verify` only to https, so `KUBERNETES_BASE_URL=http://...` sent the token in the clear with no opt-out required. The endpoint is now parsed once and must be an absolute `https` URL with a host, no embedded credentials, no query or fragment and a valid port; the skip flag does not make plaintext legal.
- **A missing in-cluster CA fell back to the public roots.** `True` does not mean "the system trust store" — `requests` uses the certifi bundle it ships with, which can also be redirected by `REQUESTS_CA_BUNDLE`. Falling back to it inside a pod widens the trust boundary from the cluster CA to every public authority, so an absent CA now refuses to start.
- **`isfile()` was not validation.** An empty or malformed PEM passed startup and failed on the first request. The bundle is now loaded with `ssl.create_default_context()` at startup. My original tests wrote **empty** CA files and asserted they were accepted, so they were pinning exactly the wrong behaviour — that is fixed, and those tests now use a real bundle.
- **A CA plus the skip flag was resolved silently in favour of skipping.** It is now a startup error, matching the policy #1168 adopted after its own review.

The same page also notes:

> Kubernetes does not guarantee that the API server has a valid certificate for the hostname `kubernetes.default.svc`; however, the control plane **is** expected to present a valid certificate for the hostname or IP address that `$KUBERNETES_SERVICE_HOST` represents.

The default address therefore becomes the advertised one. It used to be `http://127.0.0.1:8080`, a `kubectl proxy` whose setup has been commented out in `tests/create-cluster.sh` since before this operator was merged, and which put the bearer token on the wire in cleartext for anything listening on that port.

### Proof manifests

The truth table at the top is now a parametrized test, so the twelve spellings are pinned rather than described:

```console
$ pytest --disable-warnings -q
76 passed in 0.80s
```

Restoring the old expression in `tls_verify()` — the state this PR replaces — fails eleven of them:

```console
$ pytest --disable-warnings -q     # with tls_verify() reverted
FAILED tests/test_utils.py::test_tls_is_verified_by_default - assert False is...
FAILED tests/test_utils.py::test_in_cluster_ca_bundle_is_used_when_present - ...
FAILED tests/test_utils.py::test_kubernetes_ca_file_wins - AssertionError: as...
FAILED tests/test_utils.py::test_a_missing_ca_file_is_refused - Failed: DID N...
FAILED tests/test_utils.py::test_only_an_explicit_opt_in_skips_verification[false-False]
FAILED tests/test_utils.py::test_only_an_explicit_opt_in_skips_verification[False-False]
FAILED tests/test_utils.py::test_only_an_explicit_opt_in_skips_verification[0-False]
FAILED tests/test_utils.py::test_only_an_explicit_opt_in_skips_verification[no-False]
FAILED tests/test_utils.py::test_only_an_explicit_opt_in_skips_verification[-False]
FAILED tests/test_utils.py::test_only_an_explicit_opt_in_skips_verification[  -False]
FAILED tests/test_utils.py::test_only_an_explicit_opt_in_skips_verification[maybe-False]
11 failed, 50 passed in 0.32s
```

Worth reading the parameter names: the failures are `false`, `False`, `0`, `no`, `""`, `"  "` and `maybe` — every case that should have been verifying and was not. The `true`/`1`/`yes`/`on` cases pass under both versions, because under the old expression nothing anyone typed could have turned verification on for real.

One test asserts the plumbing rather than the policy, using the kwargs `responses` records, so the value the module computes is provably the value `requests` receives:

```python
assert responses.calls[0].request.req_kwargs["verify"] == verify
```

`flake8 controllers/utils.py` reports 18 findings on `main` and 17 here — all pre-existing `E501`s; the patch adds none and removes one long line.

One caveat on all of the above: `.prow.yaml` builds this operator's image but never runs `tox`, and the root `make unit` only walks directories containing a `go.mod`, so **nothing in `tests/` runs in CI today** and the invariant this PR pins is enforced only by whoever runs pytest locally. The runs above are local, against the versions pinned in `requirements.txt`. Wiring a Python presubmit into `.prow.yaml` would close that gap; it touches shared CI configuration that is yours to own, so it is not in this PR. The sibling #1168 had the same problem in a form I could fix inside the operator, and does.

### Effect on existing deployments

A pod needs no configuration: both the CA bundle and the address come from the cluster. The trade-off worth naming is that a cluster whose serving certificate does not cover the address the operator is pointed at will now fail the handshake instead of silently accepting it. That is the intended direction, but it is a behaviour change for anyone who was relying on the old default, and `KUBERNETES_CA_FILE` or `UNSAFE_SKIP_TLS_VERIFY` are the two ways out.

`HTTPS_VERIFY` becomes inert. The module constant is renamed `HTTPS_VERIFY` → `TLS_VERIFY` because it is no longer a boolean; nothing outside `controllers/utils.py` referenced it.

### Deliberately not in this patch

- Requests here still have no timeout, and a configuration failure is flattened into `status=False`, which `cluster_creation_request` reports as `progressing` before a 30-minute generic timeout. Both are real and both are adjacent rather than part of this boundary; raised as #1174.
- The line below the one this PR changes builds the token with `os.popen(f"cat {TOKEN}")`, which shells out with an environment variable interpolated into the command. That is a separate defect with a separate fix — reading the file directly also has to decide what to do when it is absent, which is currently masked by `cat` failing quietly — and it does not belong in a change about TLS. Raised separately as #1170.
- Moving these calls onto `kubernetes.client`, already a dependency, would make all of this the library's problem rather than ours. That is the right destination and much too large for a security fix.

### Notes for maintainers

- Companion change: `nephio/optional/o2ims/app/deployment.yaml` in nephio-project/catalog pins `KUBERNETES_BASE_URL` to `https://kubernetes.default.svc`, so catalog deployments keep that address until it is dropped there too. Verification still works on any cluster whose certificate carries that SAN, which is the usual case for kubeadm and kind; the catalog change just removes the reliance on it. Raised as nephio-project/catalog#146, whose title carries the blocker: it must not merge until this one ships in an image, because until then the operator's own default is `http://127.0.0.1:8080`.
- Documentation: `operators/o2ims-operator/README.md` gains a "Connecting to the Kubernetes API" section here. I found no reference to these variables in nephio-project/docs, so no companion PR there looks necessary.
- Release triage is yours to set. The change is confined to the o2ims operator's API client, its test deployment and its README.
- `SECURITY.md` asks that vulnerabilities not be reported through public issues. I have not opened a public issue for it. Say the word and I will route it through sig-security@lists.nephio.org before this goes further — same question as on #1168.
