### PR TITLE
[security][o2ims] Verify Kubernetes API TLS certificates and read the token without a shell

### DIFF
--- a/operators/o2ims-operator/README.md
+++ b/operators/o2ims-operator/README.md
@@ -105,6 +105,49 @@ kpt live init /tmp/o2ims
 kpt live apply /tmp/o2ims --reconcile-timeout=15m --output=table
 ```
 
+### Connecting to the Kubernetes API
+
+The operator verifies the API server's certificate on every request. Inside a
+pod there is nothing to configure: the CA bundle mounted at
+`/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` is used, and the address
+comes from `KUBERNETES_SERVICE_HOST`, which is the one Kubernetes expects that
+certificate to be valid for.
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `KUBERNETES_BASE_URL` | in-cluster address | API server to talk to |
+| `KUBERNETES_CA_FILE` | in-cluster CA bundle | PEM bundle used to verify the API server |
+| `UNSAFE_SKIP_TLS_VERIFY` | `false` | Development only: skip certificate verification |
+
+Running the operator outside a cluster, point it at the API server and at the
+CA that signs its certificate:
+
+```bash
+export KUBERNETES_BASE_URL=$(kubectl config view --minify \
+  -o jsonpath='{.clusters[0].cluster.server}')
+
+# The CA is embedded in most kubeconfigs and a file path in some.
+kubectl config view --raw --minify \
+  -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' \
+  | base64 -d > /tmp/cluster-ca.crt
+test -s /tmp/cluster-ca.crt || cp "$(kubectl config view --minify \
+  -o jsonpath='{.clusters[0].cluster.certificate-authority}')" /tmp/cluster-ca.crt
+export KUBERNETES_CA_FILE=/tmp/cluster-ca.crt
+
+# TOKEN is a path, not a token. Outside a pod there is no mounted one, so
+# request a short-lived credential and point at the file.
+kubectl -n o2ims create token o2ims-operator --duration=1h > /tmp/o2ims-token
+chmod 0600 /tmp/o2ims-token
+export TOKEN=/tmp/o2ims-token
+```
+
+The token expires; re-run the last three lines when it does. Inside a pod
+none of this applies, because the kubelet rotates the mounted one.
+
+`UNSAFE_SKIP_TLS_VERIFY=true` turns verification off altogether. It hands the
+service account token to an endpoint whose identity has not been checked, warns
+about it at startup, and must never be used outside development.
+
 ### Redeploying
 
 To redeploy the cluster, or to recreate the development environment, one must delete the created cluster. The Nephio mgmt cluster will be deleted automatically when running `create-cluster.sh`, but the cluster deployed by this operator has a name in the `clusterName` field. For example, it may be `edge`, thus:

--- a/operators/o2ims-operator/README.md
+++ b/operators/o2ims-operator/README.md
@@ -123,26 +123,73 @@ Running the operator outside a cluster, point it at the API server and at the
 CA that signs its certificate:
 
 ```bash
-export KUBERNETES_BASE_URL=$(kubectl config view --minify \
-  -o jsonpath='{.clusters[0].cluster.server}')
+# A function, so that a failure stops the setup without closing an
+# interactive shell, and so the token refresh can be re-run on its own.
+refresh_o2ims_token() {
+  tmp=$(mktemp /tmp/o2ims-token.XXXXXX) || return 1
+  chmod 0600 "$tmp" || { rm -f "$tmp"; return 1; }
 
-# The CA is embedded in most kubeconfigs and a file path in some.
-kubectl config view --raw --minify \
-  -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' \
-  | base64 -d > /tmp/cluster-ca.crt
-test -s /tmp/cluster-ca.crt || cp "$(kubectl config view --minify \
-  -o jsonpath='{.clusters[0].cluster.certificate-authority}')" /tmp/cluster-ca.crt
-export KUBERNETES_CA_FILE=/tmp/cluster-ca.crt
+  if ! kubectl -n o2ims create token o2ims-operator --duration=1h > "$tmp" ||
+     ! test -s "$tmp"; then
+    rm -f "$tmp"
+    echo "token refresh failed; the previous token is unchanged" >&2
+    return 1
+  fi
 
-# TOKEN is a path, not a token. Outside a pod there is no mounted one, so
-# request a short-lived credential and point at the file.
-kubectl -n o2ims create token o2ims-operator --duration=1h > /tmp/o2ims-token
-chmod 0600 /tmp/o2ims-token
-export TOKEN=/tmp/o2ims-token
+  mv -f "$tmp" /tmp/o2ims-token
+}
+
+o2ims_dev_env() {
+  # Assigned before exporting: export always succeeds, so it would hide a
+  # kubectl that failed, and an empty value falls back to the in-cluster name.
+  KUBERNETES_BASE_URL=$(kubectl config view --minify \
+    -o jsonpath='{.clusters[0].cluster.server}') || return 1
+  test -n "$KUBERNETES_BASE_URL" || {
+    echo "kubeconfig names no API server" >&2
+    return 1
+  }
+
+  # --flatten embeds the CA whether the kubeconfig holds it inline or as a
+  # path, and a path is relative to the kubeconfig rather than to this shell.
+  # The pipeline's status is base64's, and base64 succeeds on the empty input
+  # a failed kubectl leaves, so the size check is what catches that.
+  ca=$(mktemp /tmp/o2ims-ca.XXXXXX) || return 1
+  if ! kubectl config view --raw --minify --flatten \
+        -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' \
+        | base64 -d > "$ca" || ! test -s "$ca"; then
+    rm -f "$ca"
+    echo "could not extract a non-empty cluster CA from the kubeconfig" >&2
+    return 1
+  fi
+  mv -f "$ca" /tmp/cluster-ca.crt
+
+  # TOKEN is a path, not a token. Outside a pod there is no mounted one, so
+  # request a short-lived credential and point at the file. A refresh that
+  # fails is only fatal when there is no usable token from a previous one.
+  refresh_o2ims_token || test -s /tmp/o2ims-token || return 1
+
+  export KUBERNETES_BASE_URL
+  export KUBERNETES_CA_FILE=/tmp/cluster-ca.crt
+  export TOKEN=/tmp/o2ims-token
+}
+
+o2ims_dev_env
 ```
 
-The token expires; re-run the last three lines when it does. Inside a pod
-none of this applies, because the kubelet rotates the mounted one.
+The rename matters. The operator opens this file on every request, and `>`
+truncates before `kubectl` finishes writing, so a request landing in that window
+would read an empty token. A rename on the same filesystem is atomic: a reader
+sees either the whole old file or the whole new one.
+
+So does keeping the failure off that path. The redirection creates the
+temporary file before `kubectl` runs, so an expired kubeconfig or an
+unreachable API server leaves it empty; renaming that over a token that is
+still valid causes the outage the rename exists to prevent, and the operator
+reports `Kubernetes token file ... is empty`. The function above discards the
+temporary file instead and leaves the old one in place.
+
+Re-run `refresh_o2ims_token` when the token expires. Inside a pod none of this
+applies, because the kubelet rotates the mounted one.
 
 `UNSAFE_SKIP_TLS_VERIFY=true` turns verification off altogether. It hands the
 service account token to an endpoint whose identity has not been checked, warns
@@ -232,23 +279,8 @@ To run all tests in `test_utils.py` targeting a specific python version:
 tox -e py312
 ```
 
-Output:
-```bash
-py312: commands[0]> pytest --maxfail=1 --disable-warnings -q -v
-=========================================================================================== test session starts ===========================================================================================
-platform linux -- Python 3.12.3, pytest-8.3.4, pluggy-1.5.0
-cachedir: .tox/py312/.pytest_cache
-rootdir: /home/fiachra/git/nordix_github/nephio/operators/o2ims-operator
-plugins: cov-6.0.0
-collected 39 items                                                                                                                                                                                        
-
-tests/test_utils.py .......................................                                                                                                                                         [100%]
-
-=========================================================================================== 39 passed in 0.12s ============================================================================================
-  py312: OK (0.27=setup[0.02]+cmd[0.25] seconds)
-  congratulations :) (0.30 seconds)
-
-```
+`tox` exits non-zero if any test fails, which is what makes this a gate rather
+than a report. #1175 runs the same command in CI.
 
 ## Known issues
 

--- a/operators/o2ims-operator/controllers/utils.py
+++ b/operators/o2ims-operator/controllers/utils.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 ##########################################################################
 
+import ipaddress
 import logging
+import re
 import os
 import ssl
 from urllib.parse import urlsplit
@@ -31,8 +33,9 @@ LOG_LEVEL = str(os.getenv("LOG_LEVEL", "DEBUG"))
 
 LOGGER = logging.getLogger(__name__)
 
-# CA bundle Kubernetes mounts into every container
+# CA bundle and token Kubernetes mounts into every container
 IN_CLUSTER_CA_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+IN_CLUSTER_TOKEN_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 # API server address used outside a cluster
 DEFAULT_KUBERNETES_BASE_URL = "https://kubernetes.default.svc"
 
@@ -40,6 +43,32 @@ DEFAULT_KUBERNETES_BASE_URL = "https://kubernetes.default.svc"
 def env_flag(name: str) -> bool:
     """Return True only for an explicit true value; anything else is False."""
     return os.getenv(name, "").strip().lower() in ("1", "true", "yes", "on")
+
+
+# Letter-digit-hyphen labels, which is all a hostname may be. Anything a
+# second parser could read differently — percent escapes, backslashes,
+# spaces, anything non-ASCII — is simply not in here.
+HOST_LABEL = re.compile(r"\A[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?\Z")
+
+
+def is_unambiguous_host(host: str) -> bool:
+    """Whether every url parser will read this as the same host.
+
+    Named characters were refused one at a time until fuzzing the
+    validator against requests turned up two more classes at once, so
+    this allows a shape instead: an IP literal, or a DNS name.
+
+    :param host: the host as urlsplit reports it
+    :rtype: bool
+    """
+    try:
+        ipaddress.ip_address(host)
+        return True
+    except ValueError:
+        pass
+    if not host or len(host) > 253:
+        return False
+    return all(HOST_LABEL.match(label) for label in host.rstrip(".").split("."))
 
 
 def validate_api_server_url(base_url: str) -> str:
@@ -51,18 +80,40 @@ def validate_api_server_url(base_url: str) -> str:
     :return: the url, without a trailing slash
     :rtype: str
     """
-    parsed = urlsplit(base_url)
+    # urlsplit rejects an unclosed IPv6 bracket by raising, and so does reading
+    # .port on one that is not a number in range. Neither should reach the
+    # caller as a bare ValueError when every other rejection here is a
+    # RuntimeError naming what is wrong.
     try:
-        parsed.port
+        parsed = urlsplit(base_url)
+    except ValueError:
+        raise RuntimeError(
+            f"Kubernetes API url {base_url!r} cannot be parsed"
+        ) from None
+    try:
+        port = parsed.port
         problem = ""
-        if parsed.scheme != "https":
+        if any(ch < " " or ch == "\x7f" for ch in base_url):
+            # urlsplit drops some of these and keeps others, while requests
+            # percent-encodes them, so the host checked here is not always the
+            # host connected to.
+            problem = "must not contain control characters"
+        elif parsed.scheme != "https":
             problem = "must use https"
         elif not parsed.hostname:
             problem = "has no host"
+        elif not is_unambiguous_host(parsed.hostname):
+            # urlsplit keeps a backslash and a percent escape in the host;
+            # requests hands the authority to urllib3, which reads the first as
+            # a path separator and decodes the second. Either way the address
+            # checked here would not be the one connected to.
+            problem = f"has an unusable host {parsed.hostname!r}"
         elif parsed.username or parsed.password:
             problem = "must not embed credentials"
         elif parsed.query or parsed.fragment:
             problem = "must not carry a query or fragment"
+        elif port == 0:
+            problem = "has an invalid port"
     except ValueError:
         problem = "has an invalid port"
     if problem:
@@ -93,24 +144,88 @@ def kubernetes_base_url() -> str:
     :rtype: str
     """
     base_url = os.getenv("KUBERNETES_BASE_URL")
-    if base_url:
-        return validate_api_server_url(base_url)
+    advertised = in_cluster_base_url()
+    if not base_url:
+        return advertised or DEFAULT_KUBERNETES_BASE_URL
+
+    base_url = validate_api_server_url(base_url)
+    # Catalog releases before nephio-project/catalog#146 pin the in-cluster DNS
+    # name, which Kubernetes does not promise a certificate for. That value
+    # cannot be dropped in the same commit as this one, because it lives in
+    # another repository, so in a pod it resolves to the address Kubernetes
+    # does promise: the same server, named the way it is certified.
+    #
+    # Only for that deployment, which sets the address and nothing else. A CA
+    # bundle or a skip flag says the endpoint was chosen deliberately, and the
+    # bundle may only certify the name that was asked for: substituting an
+    # address there would break a working setup rather than rescue a stale one.
+    chose_a_trust_policy = bool(os.getenv("KUBERNETES_CA_FILE")) or env_flag(
+        "UNSAFE_SKIP_TLS_VERIFY"
+    )
+    if (
+        advertised
+        and not chose_a_trust_policy
+        and urlsplit(base_url).path in ("", "/")
+        and tls_origin(base_url) == tls_origin(DEFAULT_KUBERNETES_BASE_URL)
+    ):
+        LOGGER.warning(
+            "KUBERNETES_BASE_URL is %s, which Kubernetes does not guarantee a "
+            "serving certificate for; using %s instead. Remove the variable "
+            "to silence this.",
+            base_url,
+            advertised,
+        )
+        return advertised
+    return base_url
+
+
+def in_cluster_base_url() -> str:
+    """
+    :return: the address the kubelet advertises, or "" outside a pod
+    :rtype: str
+    """
     host = os.getenv("KUBERNETES_SERVICE_HOST")
     if not host:
-        return DEFAULT_KUBERNETES_BASE_URL
+        return ""
     if ":" in host and not host.startswith("["):  # IPv6 literal
         host = f"[{host}]"
     port = os.getenv("KUBERNETES_SERVICE_PORT", "443")
     return validate_api_server_url(f"https://{host}:{port}")
 
 
-def tls_verify():
+def tls_origin(base_url: str) -> tuple:
+    """Reduce a URL to the endpoint its certificate is issued for.
+
+    https://host and https://host:443 are one endpoint, as are the short
+    and long spellings of an IPv6 address, so comparing URLs as written
+    would send equivalent addresses down different trust paths.
+
+    :param base_url: an API server URL
+    :return: scheme, canonical host and effective port
+    :rtype: tuple
+    """
+    parsed = urlsplit(base_url)
+    host = parsed.hostname or ""
+    try:
+        host = ipaddress.ip_address(host).compressed
+    except ValueError:
+        host = host.lower()
+    return parsed.scheme.lower(), host, parsed.port or 443
+
+
+def tls_verify(base_url: str):
     """
     Only UNSAFE_SKIP_TLS_VERIFY disables verification; the bearer token
     below is attached to every request. In a pod the mounted CA has to
     load, because the fallback is not a failed handshake but the public
     roots requests ships with.
 
+    Returning True means the bundle requests defaults to, which is certifi
+    and which REQUESTS_CA_BUNDLE or CURL_CA_BUNDLE can redirect. That only
+    happens with no CA configured for this endpoint; a path is never
+    overridden.
+
+    :param base_url: the endpoint the token will be sent to
     :return: CA bundle path, True for the requests default bundle, or False
     :rtype: str or bool
     """
@@ -125,6 +240,16 @@ def tls_verify():
         return False
     if ca_file:
         return validate_ca_bundle(ca_file)
+    # The mounted bundle is issued for the cluster's own API server, reachable
+    # both at the advertised address and at the in-cluster name. Pinning it to
+    # some other endpoint would reject every connection to it.
+    origin = tls_origin(base_url)
+    in_cluster = in_cluster_base_url()
+    if origin not in (
+        tls_origin(in_cluster) if in_cluster else (),
+        tls_origin(DEFAULT_KUBERNETES_BASE_URL),
+    ):
+        return True
     if os.path.exists(IN_CLUSTER_CA_FILE):
         return validate_ca_bundle(IN_CLUSTER_CA_FILE)
     if os.getenv("KUBERNETES_SERVICE_HOST"):
@@ -135,8 +260,10 @@ def tls_verify():
     return True
 
 
+KUBERNETES_BASE_URL = kubernetes_base_url()
+
 # Verify the API server certificate on every request
-TLS_VERIFY = tls_verify()
+TLS_VERIFY = tls_verify(KUBERNETES_BASE_URL)
 if TLS_VERIFY is False:
     LOGGER.warning(
         "UNSAFE_SKIP_TLS_VERIFY is set: the Kubernetes API server "
@@ -148,20 +275,39 @@ if os.getenv("HTTPS_VERIFY") is not None:
         "HTTPS_VERIFY is no longer supported and is ignored; certificates "
         "are always verified unless UNSAFE_SKIP_TLS_VERIFY=true"
     )
-# Token used to communicate with Kube cluster
-TOKEN = os.getenv("TOKEN", "/var/run/secrets/kubernetes.io/serviceaccount/token")
-TOKEN = os.popen(f"cat {TOKEN}").read()
-KUBERNETES_BASE_URL = kubernetes_base_url()
 UPSTREAM_PKG_REPO = os.getenv("UPSTREAM_PKG_REPO", "catalog-infra-capi")
+CLUSTER_PROVISIONER = str(os.getenv("CLUSTER_PROVISIONER", "capi"))
+CREATION_TIMEOUT = int(os.getenv("CREATION_TIMEOUT", 1800))
 
-HEADERS_DICT = {
+BASE_HEADERS = {
     "Content-type": "application/json",
     "Accept": "application/json",
     "User-Agent": "kopf_o2ims_operator/python",
-    "Authorization": "Bearer {}".format(TOKEN),
 }
-CLUSTER_PROVISIONER = str(os.getenv("CLUSTER_PROVISIONER", "capi"))
-CREATION_TIMEOUT = int(os.getenv("CREATION_TIMEOUT", 1800))
+
+
+def read_token() -> str:
+    """Return the token, read fresh so that rotation is picked up.
+
+    An empty or blank file is refused rather than turned into a bare
+    ``Bearer``, which the API server answers with an opaque 401.
+
+    :return: the token
+    :rtype: str
+    """
+    path = os.getenv("TOKEN", IN_CLUSTER_TOKEN_FILE)
+    with open(path, encoding="utf-8") as token_file:
+        token = token_file.read().strip()
+    if not token:
+        raise RuntimeError(f"Kubernetes token file {path!r} is empty")
+    if any(character.isspace() for character in token):
+        raise RuntimeError(f"Kubernetes token file {path!r} is not a token")
+    return token
+
+
+def request_headers() -> dict:
+    """Return the API server request headers, carrying the current token."""
+    return {**BASE_HEADERS, "Authorization": f"Bearer {read_token()}"}
 
 
 def create_package_variant(
@@ -214,7 +360,7 @@ def create_package_variant(
             )
         r = requests.post(
             f"{KUBERNETES_BASE_URL}/apis/config.porch.kpt.dev/v1alpha1/namespaces/{namespace}/packagevariants",
-            headers=HEADERS_DICT,
+            headers=request_headers(),
             json=pv_body,
             verify=TLS_VERIFY,
         )
@@ -260,7 +406,7 @@ def get_package_variant(name: str = None, namespace: str = None, logger=None):
     try:
         r = requests.get(
             f"{KUBERNETES_BASE_URL}/apis/config.porch.kpt.dev/v1alpha1/namespaces/{namespace}/packagevariants/{name}",
-            headers=HEADERS_DICT,
+            headers=request_headers(),
             verify=TLS_VERIFY,
         )
     except Exception as e:
@@ -306,7 +452,7 @@ def check_o2ims_provisioning_request(
     try:
         r = requests.get(
             f"{KUBERNETES_BASE_URL}/apis/o2ims.provisioning.oran.org/v1alpha1/provisioningrequests",
-            headers=HEADERS_DICT,
+            headers=request_headers(),
             verify=TLS_VERIFY,
         )
     except Exception as e:
@@ -367,7 +513,7 @@ def get_capi_cluster(name: str = None, namespace: str = None, logger=None):
     try:
         r = requests.get(
             f"{KUBERNETES_BASE_URL}/apis/cluster.x-k8s.io/v1beta1/namespaces/{namespace}/clusters/{name}",
-            headers=HEADERS_DICT,
+            headers=request_headers(),
             verify=TLS_VERIFY,
         )
     except Exception as e:

--- a/operators/o2ims-operator/controllers/utils.py
+++ b/operators/o2ims-operator/controllers/utils.py
@@ -14,11 +14,12 @@
 # limitations under the License.
 ##########################################################################
 
+import logging
 import os
+import ssl
+from urllib.parse import urlsplit
 
 import requests
-
-requests.packages.urllib3.disable_warnings()
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 # Allowed values vanilla/Openshift
@@ -27,12 +28,130 @@ KUBERNETES_TYPE = str(os.getenv("KUBERNETES_TYPE", "vanilla")).lower()
 LABEL = {"owner": "o2ims.provisioning.oran.org.provisioningrequests"}
 # Log level of the controller
 LOG_LEVEL = str(os.getenv("LOG_LEVEL", "DEBUG"))
-# To verify HTTPs certificates when communicating with cluster
-HTTPS_VERIFY = bool(os.getenv("HTTPS_VERIFY", False))
+
+LOGGER = logging.getLogger(__name__)
+
+# CA bundle Kubernetes mounts into every container
+IN_CLUSTER_CA_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+# API server address used outside a cluster
+DEFAULT_KUBERNETES_BASE_URL = "https://kubernetes.default.svc"
+
+
+def env_flag(name: str) -> bool:
+    """Return True only for an explicit true value; anything else is False."""
+    return os.getenv(name, "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def validate_api_server_url(base_url: str) -> str:
+    """Return base_url once it is safe to send a bearer token to.
+
+    requests applies ``verify`` only to https, so a plaintext endpoint is
+    refused outright rather than merely unverified.
+
+    :return: the url, without a trailing slash
+    :rtype: str
+    """
+    parsed = urlsplit(base_url)
+    try:
+        parsed.port
+        problem = ""
+        if parsed.scheme != "https":
+            problem = "must use https"
+        elif not parsed.hostname:
+            problem = "has no host"
+        elif parsed.username or parsed.password:
+            problem = "must not embed credentials"
+        elif parsed.query or parsed.fragment:
+            problem = "must not carry a query or fragment"
+    except ValueError:
+        problem = "has an invalid port"
+    if problem:
+        raise RuntimeError(f"Kubernetes API url {base_url!r} {problem}")
+    return base_url.rstrip("/")
+
+
+def validate_ca_bundle(path: str) -> str:
+    """Return path once it actually loads as a CA bundle.
+
+    Checking the path alone would accept an empty or malformed PEM and
+    defer the failure to the first request.
+
+    :return: the path
+    :rtype: str
+    """
+    try:
+        ssl.create_default_context(cafile=path)
+    except (OSError, ssl.SSLError) as exc:
+        raise RuntimeError(f"CA bundle {path!r} is unusable: {exc}") from exc
+    return path
+
+
+def kubernetes_base_url() -> str:
+    """
+    :return: KUBERNETES_BASE_URL, else the address advertised to the pod,
+             the only one its certificate is expected to be valid for
+    :rtype: str
+    """
+    base_url = os.getenv("KUBERNETES_BASE_URL")
+    if base_url:
+        return validate_api_server_url(base_url)
+    host = os.getenv("KUBERNETES_SERVICE_HOST")
+    if not host:
+        return DEFAULT_KUBERNETES_BASE_URL
+    if ":" in host and not host.startswith("["):  # IPv6 literal
+        host = f"[{host}]"
+    port = os.getenv("KUBERNETES_SERVICE_PORT", "443")
+    return validate_api_server_url(f"https://{host}:{port}")
+
+
+def tls_verify():
+    """
+    Only UNSAFE_SKIP_TLS_VERIFY disables verification; the bearer token
+    below is attached to every request. In a pod the mounted CA has to
+    load, because the fallback is not a failed handshake but the public
+    roots requests ships with.
+
+    :return: CA bundle path, True for the requests default bundle, or False
+    :rtype: str or bool
+    """
+    unsafe = env_flag("UNSAFE_SKIP_TLS_VERIFY")
+    ca_file = os.getenv("KUBERNETES_CA_FILE")
+    if unsafe and ca_file:
+        raise RuntimeError(
+            "KUBERNETES_CA_FILE and UNSAFE_SKIP_TLS_VERIFY conflict, "
+            "refusing to guess which one was meant"
+        )
+    if unsafe:
+        return False
+    if ca_file:
+        return validate_ca_bundle(ca_file)
+    if os.path.exists(IN_CLUSTER_CA_FILE):
+        return validate_ca_bundle(IN_CLUSTER_CA_FILE)
+    if os.getenv("KUBERNETES_SERVICE_HOST"):
+        raise RuntimeError(
+            f"the in-cluster CA {IN_CLUSTER_CA_FILE} is missing; supply "
+            "KUBERNETES_CA_FILE or set UNSAFE_SKIP_TLS_VERIFY"
+        )
+    return True
+
+
+# Verify the API server certificate on every request
+TLS_VERIFY = tls_verify()
+if TLS_VERIFY is False:
+    LOGGER.warning(
+        "UNSAFE_SKIP_TLS_VERIFY is set: the Kubernetes API server "
+        "certificate will NOT be verified and the service account token "
+        "can be intercepted. Never enable this outside development."
+    )
+if os.getenv("HTTPS_VERIFY") is not None:
+    LOGGER.warning(
+        "HTTPS_VERIFY is no longer supported and is ignored; certificates "
+        "are always verified unless UNSAFE_SKIP_TLS_VERIFY=true"
+    )
 # Token used to communicate with Kube cluster
 TOKEN = os.getenv("TOKEN", "/var/run/secrets/kubernetes.io/serviceaccount/token")
 TOKEN = os.popen(f"cat {TOKEN}").read()
-KUBERNETES_BASE_URL = str(os.getenv("KUBERNETES_BASE_URL", "http://127.0.0.1:8080"))
+KUBERNETES_BASE_URL = kubernetes_base_url()
 UPSTREAM_PKG_REPO = os.getenv("UPSTREAM_PKG_REPO", "catalog-infra-capi")
 
 HEADERS_DICT = {
@@ -97,7 +216,7 @@ def create_package_variant(
             f"{KUBERNETES_BASE_URL}/apis/config.porch.kpt.dev/v1alpha1/namespaces/{namespace}/packagevariants",
             headers=HEADERS_DICT,
             json=pv_body,
-            verify=HTTPS_VERIFY,
+            verify=TLS_VERIFY,
         )
         if logger:
             logger.debug(
@@ -142,7 +261,7 @@ def get_package_variant(name: str = None, namespace: str = None, logger=None):
         r = requests.get(
             f"{KUBERNETES_BASE_URL}/apis/config.porch.kpt.dev/v1alpha1/namespaces/{namespace}/packagevariants/{name}",
             headers=HEADERS_DICT,
-            verify=HTTPS_VERIFY,
+            verify=TLS_VERIFY,
         )
     except Exception as e:
         if logger:
@@ -188,7 +307,7 @@ def check_o2ims_provisioning_request(
         r = requests.get(
             f"{KUBERNETES_BASE_URL}/apis/o2ims.provisioning.oran.org/v1alpha1/provisioningrequests",
             headers=HEADERS_DICT,
-            verify=HTTPS_VERIFY,
+            verify=TLS_VERIFY,
         )
     except Exception as e:
         if logger:
@@ -249,7 +368,7 @@ def get_capi_cluster(name: str = None, namespace: str = None, logger=None):
         r = requests.get(
             f"{KUBERNETES_BASE_URL}/apis/cluster.x-k8s.io/v1beta1/namespaces/{namespace}/clusters/{name}",
             headers=HEADERS_DICT,
-            verify=HTTPS_VERIFY,
+            verify=TLS_VERIFY,
         )
     except Exception as e:
         if logger:

--- a/operators/o2ims-operator/tests/conftest.py
+++ b/operators/o2ims-operator/tests/conftest.py
@@ -1,0 +1,43 @@
+# Copyright 2026 The Nephio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Start every run from the same environment, whatever is running it.
+
+controllers.utils resolves the API address and the CA bundle at import
+time, so a fixture cannot undo an ambient setting: by the time one runs,
+the test module has already imported the package. pytest loads conftest
+before it imports test modules, which is early enough.
+
+A pod is where this matters. The kubelet injects KUBERNETES_SERVICE_HOST
+and KUBERNETES_SERVICE_PORT even when automountServiceAccountToken is
+false, so a CI pod with no service account volume looks like a cluster
+with no CA and the import fails during collection.
+"""
+
+import os
+
+AMBIENT_KUBERNETES_ENV = (
+    "KUBERNETES_SERVICE_HOST",
+    "KUBERNETES_SERVICE_PORT",
+    "KUBERNETES_BASE_URL",
+    "KUBERNETES_CA_FILE",
+    "UNSAFE_SKIP_TLS_VERIFY",
+    "HTTPS_VERIFY",
+    # requests rewrites verify=True to whichever bundle these name.
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+)
+
+for _name in AMBIENT_KUBERNETES_ENV:
+    os.environ.pop(_name, None)

--- a/operators/o2ims-operator/tests/deployment/operator.yaml
+++ b/operators/o2ims-operator/tests/deployment/operator.yaml
@@ -101,8 +101,6 @@ spec:
         env:
           - name: 'UPSTREAM_PKG_REPO'
             value: 'catalog-infra-capi'
-          - name: 'KUBERNETES_BASE_URL'
-            value: 'https://kubernetes.default.svc'
         resources:
           requests:
             memory: "256Mi"

--- a/operators/o2ims-operator/tests/test_utils.py
+++ b/operators/o2ims-operator/tests/test_utils.py
@@ -15,6 +15,7 @@
 ##########################################################################
 
 import http.server
+import json
 import os
 import random
 import string
@@ -22,6 +23,7 @@ import threading
 
 import certifi
 import pytest
+import requests
 import responses
 
 from controllers import utils
@@ -67,19 +69,21 @@ PROVISIONING_REQUEST_URI = f"{KUBERNETES_BASE_URL}/apis/o2ims.provisioning.oran.
 CAPI_URI = f"{KUBERNETES_BASE_URL}/apis/cluster.x-k8s.io/v1beta1/namespaces/{NAMESPACE}/clusters/{NAME}"
 
 
+TEST_TOKEN = "test-token"
+
+
 @pytest.fixture(autouse=True)
-def setup_and_teardown():
-    # Create a test token in /tmp
-    test_utils_token_path = "/tmp/test_utils_token"
-    test_utils_token_path += "".join(random.choices(string.ascii_letters + string.digits, k=10))
-    os.environ["TOKEN"] = test_utils_token_path
-    with open(test_utils_token_path, "w") as fp:
-        pass
-    # Wait for tests to finish
+def setup_and_teardown(monkeypatch, tmp_path):
+    """Point TOKEN at a real token for the duration of one test.
+
+    monkeypatch restores the environment afterwards; the previous version
+    left TOKEN naming a deleted file, and wrote an empty token, so every
+    request test silently exercised an empty Authorization header.
+    """
+    token_file = tmp_path / "token"
+    token_file.write_text(TEST_TOKEN)
+    monkeypatch.setenv("TOKEN", str(token_file))
     yield
-    # Cleanup token
-    if os.path.exists(test_utils_token_path):
-        os.remove(test_utils_token_path)
 
 
 @responses.activate
@@ -273,21 +277,115 @@ def test_get_capi_cluster(http_code, status, response_2, response_2_value, excep
         )
     response = get_capi_cluster(NAME, NAMESPACE)
     assert response["status"] == status and response[response_2] == response_2_value
+    if not exception:
+        sent = responses.calls[0].request.headers["Authorization"]
+        assert sent == f"Bearer {TEST_TOKEN}"
 
 
 @pytest.fixture
 def no_ambient_tls_config(monkeypatch, tmp_path):
-    """Make the tests behave the same on a laptop and inside a pod."""
+    """Make the tests behave the same on a laptop and inside a pod.
+
+    The service variables matter as much as the CA path: tls_verify refuses
+    to fall back to the public roots when it can see it is running in a pod,
+    so leaving them set makes every default-behaviour test raise instead.
+    """
     monkeypatch.setattr(
         utils, "IN_CLUSTER_CA_FILE", str(tmp_path / "absent-ca.crt")
     )
-    monkeypatch.delenv("KUBERNETES_CA_FILE", raising=False)
-    monkeypatch.delenv("UNSAFE_SKIP_TLS_VERIFY", raising=False)
+    for name in (
+        "KUBERNETES_CA_FILE",
+        "UNSAFE_SKIP_TLS_VERIFY",
+        "KUBERNETES_SERVICE_HOST",
+        "KUBERNETES_SERVICE_PORT",
+        "KUBERNETES_BASE_URL",
+        # requests rewrites verify=True to whichever bundle these name, so a
+        # test asserting the default would see that path instead.
+        "REQUESTS_CA_BUNDLE",
+        "CURL_CA_BUNDLE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+# Every spelling worth asking requests about: the ones this validator is
+# meant to accept, and the ones that have historically parsed differently
+# here than they do on the wire.
+URL_CORPUS = [
+    "https://10.96.0.1:443",
+    "https://10.96.0.1",
+    "https://kubernetes.default.svc",
+    "https://kubernetes.default.svc:443",
+    "https://KUBERNETES.DEFAULT.SVC",
+    "https://[fd00::1]:443",
+    "https://[fd00:0:0:0:0:0:0:1]:443",
+    "https://api.example.com:6443",
+    "https://api.example.com:6443/prefix",
+    "https://api.example.com:6443/prefix/",
+    "http://10.96.0.1:443",
+    "https://user:pass@10.96.0.1:443",
+    "https://10.96.0.1:443?a=b",
+    "https://10.96.0.1:443#frag",
+    "https://10.96.0.1:0",
+    "https://10.96.0.1:99999",
+    "https://10.96.0.1:notaport",
+    "https://[unclosed",
+    "https://",
+    "https://10.96.0.1" + chr(92) + "proxy",
+    "https://10.96.0.1" + chr(92) + chr(92) + "evil.example",
+    "https://api.example.com" + chr(92) + "path",
+    "https://10.96.0.1 /proxy",
+    "https://10.96.0.1\t.evil",
+    "https://10.96.0.1\n",
+    "https://10.96.0.1\x00.evil",
+    "https://10.96.0.1\x7f.evil",
+    "https:/" + chr(92) + "/" + chr(92) + "evil.example",
+]
+
+
+@pytest.mark.parametrize("base_url", URL_CORPUS)
+def test_what_is_validated_is_what_requests_connects_to(base_url):
+    """Whatever survives validation has to be an address requests agrees
+    about.
+
+    Guessing which characters urlsplit and urllib3 disagree over is how
+    the control-character and backslash differentials got in. This asks
+    requests instead, so a parser change in a dependency shows up here
+    rather than as a token sent to an unchecked host.
+    """
+    try:
+        validated = utils.validate_api_server_url(base_url)
+    except RuntimeError:
+        return  # refused, so there is no address to disagree about
+
+    prepared = requests.Request("GET", validated).prepare().url
+    assert utils.tls_origin(validated) == utils.tls_origin(prepared), (
+        f"{validated!r} was accepted but requests prepares {prepared!r}"
+    )
+
+
+@pytest.mark.parametrize("left, right", [
+    ("https://10.96.0.1", "https://10.96.0.1:443"),
+    ("https://kubernetes.default.svc", "https://KUBERNETES.DEFAULT.SVC:443"),
+    ("https://[::ffff:a60:1]:443", "https://[0:0:0:0:0:ffff:a60:1]:443"),
+    ("https://host:6443/api", "https://host:6443/healthz"),
+])
+def test_one_endpoint_has_one_origin(left, right):
+    assert utils.tls_origin(left) == utils.tls_origin(right)
+
+
+@pytest.mark.parametrize("left, right", [
+    ("https://10.96.0.1:443", "http://10.96.0.1:443"),
+    ("https://10.96.0.1:443", "https://10.96.0.1:6443"),
+    ("https://10.96.0.1:443", "https://10.96.0.2:443"),
+    ("https://kubernetes.default.svc", "https://kubernetes.default.svc.other"),
+])
+def test_different_endpoints_have_different_origins(left, right):
+    assert utils.tls_origin(left) != utils.tls_origin(right)
 
 
 def test_tls_is_verified_by_default(no_ambient_tls_config):
     # True is what requests calls "verify against the system trust store"
-    assert utils.tls_verify() is True
+    assert utils.tls_verify(utils.kubernetes_base_url()) is True
 
 
 def usable_ca_bundle(tmp_path, name):
@@ -302,7 +400,84 @@ def test_in_cluster_ca_bundle_is_used_when_present(
 ):
     ca_file = usable_ca_bundle(tmp_path, "ca.crt")
     monkeypatch.setattr(utils, "IN_CLUSTER_CA_FILE", ca_file)
-    assert utils.tls_verify() == ca_file
+    assert utils.tls_verify(utils.kubernetes_base_url()) == ca_file
+
+
+def test_another_endpoint_keeps_the_default_bundle(
+    no_ambient_tls_config, monkeypatch, tmp_path
+):
+    """The mounted bundle belongs to the cluster's API server, not to
+    whatever else this operator is pointed at."""
+    monkeypatch.setattr(
+        utils, "IN_CLUSTER_CA_FILE", usable_ca_bundle(tmp_path, "ca.crt"))
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+    monkeypatch.setenv("KUBERNETES_SERVICE_PORT", "443")
+    monkeypatch.setenv("KUBERNETES_BASE_URL", "https://other.example:6443")
+    assert utils.tls_verify(utils.kubernetes_base_url()) is True
+
+
+def test_the_advertised_address_uses_the_mounted_bundle(
+    no_ambient_tls_config, monkeypatch, tmp_path
+):
+    ca_file = usable_ca_bundle(tmp_path, "ca.crt")
+    monkeypatch.setattr(utils, "IN_CLUSTER_CA_FILE", ca_file)
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+    monkeypatch.setenv("KUBERNETES_SERVICE_PORT", "443")
+    for base_url in ("https://10.96.0.1:443", utils.DEFAULT_KUBERNETES_BASE_URL):
+        monkeypatch.setenv("KUBERNETES_BASE_URL", base_url)
+        assert utils.tls_verify(utils.kubernetes_base_url()) == ca_file
+
+
+@pytest.mark.parametrize("base_url", [
+    "https://10.96.0.1:443",
+    "https://10.96.0.1",                      # 443 is implicit
+    "https://kubernetes.default.svc",
+    "https://kubernetes.default.svc:443",
+    "https://KUBERNETES.DEFAULT.SVC",
+    "https://10.96.0.1:443/",
+])
+def test_equivalent_cluster_addresses_use_the_mounted_bundle(
+    no_ambient_tls_config, monkeypatch, tmp_path, base_url
+):
+    """The certificate does not change with the notation, so neither
+    should the bundle chosen to check it."""
+    ca_file = usable_ca_bundle(tmp_path, "ca.crt")
+    monkeypatch.setattr(utils, "IN_CLUSTER_CA_FILE", ca_file)
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+    monkeypatch.setenv("KUBERNETES_SERVICE_PORT", "443")
+    monkeypatch.setenv("KUBERNETES_BASE_URL", base_url)
+    assert utils.tls_verify(utils.kubernetes_base_url()) == ca_file
+
+
+@pytest.mark.parametrize("host, base_url", [
+    ("fd00::1", "https://[fd00:0:0:0:0:0:0:1]:443"),
+    ("fd00::1", "https://[FD00::1]:443"),
+])
+def test_equivalent_ipv6_spellings_use_the_mounted_bundle(
+    no_ambient_tls_config, monkeypatch, tmp_path, host, base_url
+):
+    ca_file = usable_ca_bundle(tmp_path, "ca.crt")
+    monkeypatch.setattr(utils, "IN_CLUSTER_CA_FILE", ca_file)
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", host)
+    monkeypatch.setenv("KUBERNETES_SERVICE_PORT", "443")
+    monkeypatch.setenv("KUBERNETES_BASE_URL", base_url)
+    assert utils.tls_verify(utils.kubernetes_base_url()) == ca_file
+
+
+@pytest.mark.parametrize("base_url", [
+    "https://10.96.0.1:6443",                 # same host, different port
+    "https://10.96.0.2:443",
+    "https://kubernetes.default.svc.other:443",
+])
+def test_a_different_origin_keeps_the_default_bundle(
+    no_ambient_tls_config, monkeypatch, tmp_path, base_url
+):
+    monkeypatch.setattr(
+        utils, "IN_CLUSTER_CA_FILE", usable_ca_bundle(tmp_path, "ca.crt"))
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+    monkeypatch.setenv("KUBERNETES_SERVICE_PORT", "443")
+    monkeypatch.setenv("KUBERNETES_BASE_URL", base_url)
+    assert utils.tls_verify(utils.kubernetes_base_url()) is True
 
 
 def test_kubernetes_ca_file_wins(no_ambient_tls_config, monkeypatch, tmp_path):
@@ -310,14 +485,14 @@ def test_kubernetes_ca_file_wins(no_ambient_tls_config, monkeypatch, tmp_path):
         utils, "IN_CLUSTER_CA_FILE", usable_ca_bundle(tmp_path, "in-cluster.crt"))
     configured = usable_ca_bundle(tmp_path, "configured.crt")
     monkeypatch.setenv("KUBERNETES_CA_FILE", configured)
-    assert utils.tls_verify() == configured
+    assert utils.tls_verify(utils.kubernetes_base_url()) == configured
 
 
 def test_a_missing_ca_file_is_refused(no_ambient_tls_config, monkeypatch, tmp_path):
     missing = str(tmp_path / "missing.crt")
     monkeypatch.setenv("KUBERNETES_CA_FILE", missing)
     with pytest.raises(RuntimeError, match=missing):
-        utils.tls_verify()
+        utils.tls_verify(utils.kubernetes_base_url())
 
 
 @pytest.mark.parametrize("content", ["", "   ", "not a pem\n", "-----BEGIN-----"])
@@ -329,7 +504,7 @@ def test_an_unusable_ca_bundle_is_refused(
     bundle.write_text(content)
     monkeypatch.setenv("KUBERNETES_CA_FILE", str(bundle))
     with pytest.raises(RuntimeError, match="unusable"):
-        utils.tls_verify()
+        utils.tls_verify(utils.kubernetes_base_url())
 
 
 def test_a_ca_bundle_and_skip_verify_together_are_refused(
@@ -338,7 +513,7 @@ def test_a_ca_bundle_and_skip_verify_together_are_refused(
     monkeypatch.setenv("KUBERNETES_CA_FILE", usable_ca_bundle(tmp_path, "ca.crt"))
     monkeypatch.setenv("UNSAFE_SKIP_TLS_VERIFY", "true")
     with pytest.raises(RuntimeError, match="conflict"):
-        utils.tls_verify()
+        utils.tls_verify(utils.kubernetes_base_url())
 
 
 def test_a_missing_in_cluster_ca_is_refused(
@@ -348,7 +523,7 @@ def test_a_missing_in_cluster_ca_is_refused(
     monkeypatch.setattr(utils, "IN_CLUSTER_CA_FILE", str(tmp_path / "absent.crt"))
     monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
     with pytest.raises(RuntimeError, match="in-cluster CA"):
-        utils.tls_verify()
+        utils.tls_verify(utils.kubernetes_base_url())
 
 
 def test_a_plaintext_endpoint_is_rejected_and_never_contacted(monkeypatch):
@@ -384,11 +559,95 @@ def test_a_plaintext_endpoint_is_rejected_and_never_contacted(monkeypatch):
     "https://api.example.com:6443?token=x",
     "https://api.example.com:6443#f",
     "https://api.example.com:not-a-port",
+    "https://api.example.com:0",
+    # urlsplit and requests disagree about these: the host validated here
+    # would not be the host connected to.
+    "https://api.example.com\t.evil",
+    "https://api.example.com\n",
+    "https:/\\/\\evil.example",
 ])
 def test_an_unusable_endpoint_is_rejected(monkeypatch, base_url):
     monkeypatch.setenv("KUBERNETES_BASE_URL", base_url)
     with pytest.raises(RuntimeError):
         utils.kubernetes_base_url()
+
+
+@pytest.mark.parametrize("base_url, problem", [
+    ("https://[unclosed", "cannot be parsed"),
+    ("https://host:notaport", "invalid port"),
+    ("https://host:99999", "invalid port"),
+])
+def test_an_unparseable_endpoint_is_rejected_as_such(base_url, problem):
+    """urlsplit raises on some of these and .port on others; neither
+    should reach the caller as a bare ValueError."""
+    with pytest.raises(RuntimeError, match=problem):
+        utils.validate_api_server_url(base_url)
+
+
+@pytest.mark.parametrize("base_url", [
+    "https://api.example.com\x00.evil",
+    "https://api.example.com\x7f.evil",
+    "https://api.example.com\x1f.evil",
+])
+def test_a_control_character_endpoint_is_rejected(base_url):
+    """os.environ refuses a NUL, so these go straight to the validator.
+
+    urlsplit drops some of these and keeps others while requests
+    percent-encodes them, so the host validated is not the host connected to.
+    """
+    with pytest.raises(RuntimeError, match="control characters"):
+        utils.validate_api_server_url(base_url)
+
+
+@pytest.mark.parametrize("base_url", [
+    "https://kubernetes.default.svc",
+    "https://kubernetes.default.svc:443",
+    "https://kubernetes.default.svc/",
+])
+def test_the_legacy_catalog_address_resolves_to_the_advertised_one(
+    no_ambient_tls_config, monkeypatch, base_url
+):
+    """catalog#146 removes this value, but it cannot land in the same
+    commit, so a pod running the new image with the old package still
+    has to reach a name the certificate covers."""
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+    monkeypatch.setenv("KUBERNETES_SERVICE_PORT", "443")
+    monkeypatch.setenv("KUBERNETES_BASE_URL", base_url)
+    assert utils.kubernetes_base_url() == "https://10.96.0.1:443"
+
+
+@pytest.mark.parametrize("name, value", [
+    ("KUBERNETES_CA_FILE", "/etc/o2ims/proxy-ca.crt"),
+    ("UNSAFE_SKIP_TLS_VERIFY", "true"),
+])
+def test_the_legacy_address_is_kept_when_trust_was_configured(
+    no_ambient_tls_config, monkeypatch, name, value
+):
+    """A bundle names the endpoint it certifies. Substituting the address
+    under it turns a working proxy into a hostname mismatch."""
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+    monkeypatch.setenv("KUBERNETES_SERVICE_PORT", "443")
+    monkeypatch.setenv("KUBERNETES_BASE_URL", "https://kubernetes.default.svc")
+    monkeypatch.setenv(name, value)
+    assert utils.kubernetes_base_url() == "https://kubernetes.default.svc"
+
+
+def test_the_legacy_address_is_kept_outside_a_pod(no_ambient_tls_config,
+                                                  monkeypatch):
+    monkeypatch.setenv("KUBERNETES_BASE_URL", "https://kubernetes.default.svc")
+    assert utils.kubernetes_base_url() == "https://kubernetes.default.svc"
+
+
+@pytest.mark.parametrize("base_url", [
+    "https://api.example.com:6443",
+    "https://kubernetes.default.svc/proxy-prefix",
+])
+def test_any_other_endpoint_is_respected(no_ambient_tls_config, monkeypatch,
+                                         base_url):
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+    monkeypatch.setenv("KUBERNETES_SERVICE_PORT", "443")
+    monkeypatch.setenv("KUBERNETES_BASE_URL", base_url)
+    assert utils.kubernetes_base_url() == base_url
 
 
 def test_a_trailing_slash_is_normalised(monkeypatch):
@@ -417,16 +676,71 @@ def test_only_an_explicit_opt_in_skips_verification(
     no_ambient_tls_config, monkeypatch, value, verification_skipped
 ):
     monkeypatch.setenv("UNSAFE_SKIP_TLS_VERIFY", value)
-    assert (utils.tls_verify() is False) == verification_skipped
+    assert (utils.tls_verify(utils.kubernetes_base_url()) is False) == verification_skipped
 
 
 @responses.activate
 @pytest.mark.parametrize("verify", [True, "/etc/ssl/certs/test-ca.crt"])
 def test_requests_carry_the_verify_setting(monkeypatch, verify):
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+    monkeypatch.delenv("CURL_CA_BUNDLE", raising=False)
     monkeypatch.setattr(utils, "TLS_VERIFY", verify)
     responses.get(CAPI_URI, json=TEST_JSON, status=200)
     get_capi_cluster(NAME, NAMESPACE)
     assert responses.calls[0].request.req_kwargs["verify"] == verify
+
+
+def exercise_create_package_variant():
+    """Two requests: the lookup that misses, then the creation."""
+    responses.get(PACKAGE_VARIANTS_URI + f"/{NAME}", json=TEST_JSON, status=404)
+    responses.post(PACKAGE_VARIANTS_URI, json=TEST_JSON, status=201)
+    params = PV_PARAM.copy()
+    params.update({"create": True})
+    create_package_variant(NAME, NAMESPACE, params)
+
+
+def exercise_get_package_variant():
+    responses.get(PACKAGE_VARIANTS_URI + f"/{NAME}", json=TEST_JSON, status=200)
+    get_package_variant(NAME, NAMESPACE)
+
+
+def exercise_check_o2ims_provisioning_request():
+    responses.get(
+        PROVISIONING_REQUEST_URI,
+        json={"status": {"provisioningStatus": "fulfilled"}},
+        status=200,
+    )
+    check_o2ims_provisioning_request(NAME, NAMESPACE)
+
+
+def exercise_get_capi_cluster():
+    responses.get(CAPI_URI, json=TEST_JSON, status=200)
+    get_capi_cluster(NAME, NAMESPACE)
+
+
+@responses.activate
+@pytest.mark.parametrize("exercise", [
+    exercise_create_package_variant,
+    exercise_get_package_variant,
+    exercise_check_o2ims_provisioning_request,
+    exercise_get_capi_cluster,
+])
+def test_every_api_call_verifies_and_authenticates(monkeypatch, exercise):
+    """Every request that carries the token has to check the certificate.
+
+    Asserting this on one path leaves the others free to lose either,
+    and both are one keyword argument each.
+    """
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+    monkeypatch.delenv("CURL_CA_BUNDLE", raising=False)
+    monkeypatch.setattr(utils, "TLS_VERIFY", "/etc/pki/expected.crt")
+
+    exercise()
+
+    assert responses.calls, "the exercise made no request"
+    for call in responses.calls:
+        assert call.request.req_kwargs["verify"] == "/etc/pki/expected.crt"
+        assert call.request.headers["Authorization"] == f"Bearer {TEST_TOKEN}"
 
 
 @pytest.mark.parametrize(
@@ -456,3 +770,107 @@ def test_kubernetes_base_url(monkeypatch, environment, expected):
     for name, value in environment.items():
         monkeypatch.setenv(name, value)
     assert utils.kubernetes_base_url() == expected
+
+# Service account token tests
+
+
+def test_a_token_path_is_never_passed_to_a_shell(monkeypatch, tmp_path):
+    """A path is opened, not executed, however it is spelled."""
+    marker = tmp_path / "pwned"
+    monkeypatch.setenv("TOKEN", f"{tmp_path}/absent; touch {marker}")
+    with pytest.raises(OSError):
+        utils.read_token()
+    assert not marker.exists()
+
+
+def test_a_missing_token_file_is_not_silently_empty(monkeypatch, tmp_path):
+    """An unreadable token must not degrade into an empty Bearer header."""
+    monkeypatch.setenv("TOKEN", str(tmp_path / "absent"))
+    with pytest.raises(OSError):
+        utils.read_token()
+
+
+@pytest.mark.parametrize("content", ["tok", "tok\n", "  tok\r\n"])
+def test_token_surroundings_are_stripped(monkeypatch, tmp_path, content):
+    """requests rejects a header value with a trailing newline."""
+    token_file = tmp_path / "token"
+    token_file.write_text(content)
+    monkeypatch.setenv("TOKEN", str(token_file))
+    assert utils.read_token() == "tok"
+
+
+@responses.activate
+def test_each_request_carries_the_current_token(monkeypatch, tmp_path):
+    """Kubernetes rotates the projected token while the operator runs."""
+    token_file = tmp_path / "token"
+    token_file.write_text("first")
+    monkeypatch.setenv("TOKEN", str(token_file))
+    responses.get(CAPI_URI, json=TEST_JSON, status=200)
+    responses.get(CAPI_URI, json=TEST_JSON, status=200)
+
+    get_capi_cluster(NAME, NAMESPACE)
+    token_file.write_text("second")
+    get_capi_cluster(NAME, NAMESPACE)
+
+    sent = [call.request.headers["Authorization"] for call in responses.calls]
+    assert sent == ["Bearer first", "Bearer second"]
+
+
+@pytest.mark.parametrize("content", ["", " ", "\n", "\r\n", " \t \r\n"])
+def test_an_empty_or_blank_token_is_refused(monkeypatch, tmp_path, content):
+    """An empty file used to become `Authorization: Bearer `."""
+    token_file = tmp_path / "token"
+    token_file.write_text(content)
+    monkeypatch.setenv("TOKEN", str(token_file))
+    with pytest.raises(RuntimeError, match="empty"):
+        utils.read_token()
+
+
+@pytest.mark.parametrize("content", ["tok en", "tok\nen", "tok\ten"])
+def test_a_token_with_internal_whitespace_is_refused(
+    monkeypatch, tmp_path, content
+):
+    """requests accepts such a header value; http.client rejects it on the wire."""
+    token_file = tmp_path / "token"
+    token_file.write_text(content)
+    monkeypatch.setenv("TOKEN", str(token_file))
+    with pytest.raises(RuntimeError, match="not a token"):
+        utils.read_token()
+
+
+@responses.activate
+def test_an_invalid_token_stops_before_any_request_is_made(monkeypatch, tmp_path):
+    token_file = tmp_path / "token"
+    token_file.write_text("")
+    monkeypatch.setenv("TOKEN", str(token_file))
+    responses.get(CAPI_URI, json=TEST_JSON, status=200)
+
+    get_capi_cluster(NAME, NAMESPACE)
+
+    assert len(responses.calls) == 0
+
+
+@responses.activate
+def test_create_package_variant_refreshes_the_token_between_get_and_post(
+    monkeypatch, tmp_path
+):
+    """The GET and the POST in one call must not share a stale token."""
+    token_file = tmp_path / "token"
+    token_file.write_text("first")
+    monkeypatch.setenv("TOKEN", str(token_file))
+
+    def rotate(request):
+        token_file.write_text("second")
+        return (404, {}, json.dumps(TEST_JSON))
+
+    responses.add_callback(
+        responses.GET, f"{PACKAGE_VARIANTS_URI}/{NAME}", callback=rotate,
+        content_type="application/json")
+    responses.post(PACKAGE_VARIANTS_URI, json=TEST_JSON, status=201)
+
+    params = PV_PARAM.copy()
+    params.update({"create": True})
+    create_package_variant(NAME, NAMESPACE, params)
+
+    sent = [call.request.headers["Authorization"] for call in responses.calls]
+    assert sent == ["Bearer first", "Bearer second"]

--- a/operators/o2ims-operator/tests/test_utils.py
+++ b/operators/o2ims-operator/tests/test_utils.py
@@ -14,12 +14,17 @@
 # limitations under the License.
 ##########################################################################
 
-import responses
+import http.server
 import os
-import pytest
 import random
 import string
+import threading
 
+import certifi
+import pytest
+import responses
+
+from controllers import utils
 from controllers.utils import (
     KUBERNETES_BASE_URL,
     create_package_variant,
@@ -268,3 +273,186 @@ def test_get_capi_cluster(http_code, status, response_2, response_2_value, excep
         )
     response = get_capi_cluster(NAME, NAMESPACE)
     assert response["status"] == status and response[response_2] == response_2_value
+
+
+@pytest.fixture
+def no_ambient_tls_config(monkeypatch, tmp_path):
+    """Make the tests behave the same on a laptop and inside a pod."""
+    monkeypatch.setattr(
+        utils, "IN_CLUSTER_CA_FILE", str(tmp_path / "absent-ca.crt")
+    )
+    monkeypatch.delenv("KUBERNETES_CA_FILE", raising=False)
+    monkeypatch.delenv("UNSAFE_SKIP_TLS_VERIFY", raising=False)
+
+
+def test_tls_is_verified_by_default(no_ambient_tls_config):
+    # True is what requests calls "verify against the system trust store"
+    assert utils.tls_verify() is True
+
+
+def usable_ca_bundle(tmp_path, name):
+    """Return a path holding a bundle OpenSSL will actually load."""
+    bundle = tmp_path / name
+    bundle.write_bytes(open(certifi.where(), "rb").read())
+    return str(bundle)
+
+
+def test_in_cluster_ca_bundle_is_used_when_present(
+    no_ambient_tls_config, monkeypatch, tmp_path
+):
+    ca_file = usable_ca_bundle(tmp_path, "ca.crt")
+    monkeypatch.setattr(utils, "IN_CLUSTER_CA_FILE", ca_file)
+    assert utils.tls_verify() == ca_file
+
+
+def test_kubernetes_ca_file_wins(no_ambient_tls_config, monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        utils, "IN_CLUSTER_CA_FILE", usable_ca_bundle(tmp_path, "in-cluster.crt"))
+    configured = usable_ca_bundle(tmp_path, "configured.crt")
+    monkeypatch.setenv("KUBERNETES_CA_FILE", configured)
+    assert utils.tls_verify() == configured
+
+
+def test_a_missing_ca_file_is_refused(no_ambient_tls_config, monkeypatch, tmp_path):
+    missing = str(tmp_path / "missing.crt")
+    monkeypatch.setenv("KUBERNETES_CA_FILE", missing)
+    with pytest.raises(RuntimeError, match=missing):
+        utils.tls_verify()
+
+
+@pytest.mark.parametrize("content", ["", "   ", "not a pem\n", "-----BEGIN-----"])
+def test_an_unusable_ca_bundle_is_refused(
+    no_ambient_tls_config, monkeypatch, tmp_path, content
+):
+    """A path check alone would defer this to the first request."""
+    bundle = tmp_path / "ca.crt"
+    bundle.write_text(content)
+    monkeypatch.setenv("KUBERNETES_CA_FILE", str(bundle))
+    with pytest.raises(RuntimeError, match="unusable"):
+        utils.tls_verify()
+
+
+def test_a_ca_bundle_and_skip_verify_together_are_refused(
+    no_ambient_tls_config, monkeypatch, tmp_path
+):
+    monkeypatch.setenv("KUBERNETES_CA_FILE", usable_ca_bundle(tmp_path, "ca.crt"))
+    monkeypatch.setenv("UNSAFE_SKIP_TLS_VERIFY", "true")
+    with pytest.raises(RuntimeError, match="conflict"):
+        utils.tls_verify()
+
+
+def test_a_missing_in_cluster_ca_is_refused(
+    no_ambient_tls_config, monkeypatch, tmp_path
+):
+    """In a pod, an absent CA must not fall back to the public roots."""
+    monkeypatch.setattr(utils, "IN_CLUSTER_CA_FILE", str(tmp_path / "absent.crt"))
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+    with pytest.raises(RuntimeError, match="in-cluster CA"):
+        utils.tls_verify()
+
+
+def test_a_plaintext_endpoint_is_rejected_and_never_contacted(monkeypatch):
+    """requests ignores verify for http, so the token would go out in clear."""
+    contacted = []
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            contacted.append(self.headers.get("Authorization"))
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, *args):
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        monkeypatch.setenv(
+            "KUBERNETES_BASE_URL", f"http://127.0.0.1:{server.server_address[1]}")
+        with pytest.raises(RuntimeError, match="must use https"):
+            utils.kubernetes_base_url()
+    finally:
+        server.shutdown()
+
+    assert contacted == []
+
+
+@pytest.mark.parametrize("base_url", [
+    "kubernetes.default.svc",
+    "https://",
+    "https://user:pass@api.example.com:6443",
+    "https://api.example.com:6443?token=x",
+    "https://api.example.com:6443#f",
+    "https://api.example.com:not-a-port",
+])
+def test_an_unusable_endpoint_is_rejected(monkeypatch, base_url):
+    monkeypatch.setenv("KUBERNETES_BASE_URL", base_url)
+    with pytest.raises(RuntimeError):
+        utils.kubernetes_base_url()
+
+
+def test_a_trailing_slash_is_normalised(monkeypatch):
+    monkeypatch.setenv("KUBERNETES_BASE_URL", "https://api.example.com:6443/")
+    assert utils.kubernetes_base_url() == "https://api.example.com:6443"
+
+
+@pytest.mark.parametrize(
+    "value, verification_skipped",
+    [
+        ("true", True),
+        ("True", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+        ("false", False),
+        ("False", False),
+        ("0", False),
+        ("no", False),
+        ("", False),
+        ("  ", False),
+        ("maybe", False),
+    ],
+)
+def test_only_an_explicit_opt_in_skips_verification(
+    no_ambient_tls_config, monkeypatch, value, verification_skipped
+):
+    monkeypatch.setenv("UNSAFE_SKIP_TLS_VERIFY", value)
+    assert (utils.tls_verify() is False) == verification_skipped
+
+
+@responses.activate
+@pytest.mark.parametrize("verify", [True, "/etc/ssl/certs/test-ca.crt"])
+def test_requests_carry_the_verify_setting(monkeypatch, verify):
+    monkeypatch.setattr(utils, "TLS_VERIFY", verify)
+    responses.get(CAPI_URI, json=TEST_JSON, status=200)
+    get_capi_cluster(NAME, NAMESPACE)
+    assert responses.calls[0].request.req_kwargs["verify"] == verify
+
+
+@pytest.mark.parametrize(
+    "environment, expected",
+    [
+        (
+            {"KUBERNETES_BASE_URL": "https://api.example.com:6443"},
+            "https://api.example.com:6443",
+        ),
+        (
+            {"KUBERNETES_SERVICE_HOST": "10.96.0.1",
+             "KUBERNETES_SERVICE_PORT": "443"},
+            "https://10.96.0.1:443",
+        ),
+        ({"KUBERNETES_SERVICE_HOST": "fd00::1"}, "https://[fd00::1]:443"),
+        ({"KUBERNETES_SERVICE_HOST": "[fd00::1]"}, "https://[fd00::1]:443"),
+        ({}, "https://kubernetes.default.svc"),
+    ],
+)
+def test_kubernetes_base_url(monkeypatch, environment, expected):
+    for name in (
+        "KUBERNETES_BASE_URL",
+        "KUBERNETES_SERVICE_HOST",
+        "KUBERNETES_SERVICE_PORT",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    for name, value in environment.items():
+        monkeypatch.setenv(name, value)
+    assert utils.kubernetes_base_url() == expected


### PR DESCRIPTION
> **This supersedes #1169, which is closed.** Both fixes land here as two reviewable commits against one tree.
>
> They were separate PRs, and that was wrong. The main-branch postsubmit publishes `nephio/o2ims-operator:latest` on every merge:
>
> ```
> --destination=nephio/o2ims-operator:${BUILD_ID} --destination=nephio/o2ims-operator:latest
> ```
>
> Merging the TLS fix alone would therefore publish an image that verifies certificates but still builds its bearer token through `os.popen` and still never re-reads it — while the README it ships with says the kubelet rotates that token. One merge, one image, no window in which a published `latest` carries a defect the project already has a fix for.

Second of a small series on the operators' Kubernetes clients, after #1168. The first commit makes the operator verify the Kubernetes API server's certificate; the second stops building the bearer token through a shell and re-reads it per request.

`controllers/utils.py` resolves the bearer token by interpolating an environment variable into a shell command:

```python
TOKEN = os.getenv("TOKEN", "/var/run/secrets/kubernetes.io/serviceaccount/token")
TOKEN = os.popen(f"cat {TOKEN}").read()
```

`TOKEN` is documented as a path — `tests/create-cluster.sh` sets it to `/tmp/porch-token` — but it reaches a shell verbatim, so whatever it contains runs:

```console
$ TOKEN='/absent; touch /tmp/tmpXXXX/pwned'
os.popen : token=''  marker created: True
open()   : FileNotFoundError          marker created: False
```

Two things are visible in that output. The injected `touch` executed, and the token came back empty: `cat` wrote its complaint to stderr and `.read()` returned `""`. CWE-78, and a failure mode that hides itself.

### What the empty token does

`HEADERS_DICT` is built from it at import, so the operator starts with `Authorization: Bearer ` and every call to the API server answers 401. The callers turn that into `{"status": False, "reason": "unauthorized"}`, which is what a reader of the logs sees — nothing points at the token file.

The same structure has a second consequence that has nothing to do with the shell. The header is built once and never rebuilt, while Kubernetes rotates the projected token it mounts into the pod. Once the value read at startup expires, the operator gets 401 on everything until someone restarts it, and reports the same `unauthorized` on the way down.

### Why this is not a two-line patch

Swapping `os.popen` for `open()` is the obvious fix, and on its own it forces a choice about the unreadable-file case that `cat` currently papers over. Both available answers are bad:

- Raise at import, and the operator refuses to start anywhere the file is absent — including `pytest`, which imports the module before its fixtures run.
- Swallow the error, and today's silent 401s survive the fix.

Reading the token where it is used answers the question instead of choosing: the caller sees the real error, at the point where it can be reported, and rotation stops being a problem because there is no longer a value cached from startup.

```python
def read_token() -> str:
    """Return the token, read fresh so that rotation is picked up."""
    path = os.getenv("TOKEN", IN_CLUSTER_TOKEN_FILE)
    with open(path, encoding="utf-8") as token_file:
        return token_file.read().strip()


def request_headers() -> dict:
    """Return the API server request headers, carrying the current token."""
    return {**BASE_HEADERS, "Authorization": f"Bearer {read_token()}"}
```

The `.strip()` is not cosmetic. A token file written with `echo` ends in a newline, and `requests` accepts such a header value while `http.client` rejects it on the wire:

```console
'Bearer tok'    -> sent, server saw 'Bearer tok'
'Bearer tok\n'  -> ValueError: Invalid header value b'Bearer tok\n'
```

### Proof manifests

```console
$ pytest --disable-warnings -q      # combined tree, both commits
163 passed in 1.02s
```

Run in the image the operator ships from, against `git archive HEAD` rather than a working directory, on a laptop and inside a simulated pod:

```console
$ podman run --rm -v $PWD:/w -w /w \
    -e KUBERNETES_SERVICE_HOST=10.96.0.1 -e KUBERNETES_SERVICE_PORT=443 \
    python:3.12.10-alpine3.21 sh -c '...mount token and ca.crt...; tox -e py312'
163 passed in 1.46s
```

That second run is not decoration. An earlier version of this branch passed on a laptop and failed eight tests in a pod, because the fixture that claimed to isolate the environment did not clear `KUBERNETES_SERVICE_HOST`.

Restoring the original semantics — `os.popen` back in `read_token`, and the token captured once at startup instead of per request — fails fifteen of them, listed in full so the count can be checked against the list:

```console
$ pytest --disable-warnings -q      # with main's semantics restored
FAILED tests/test_utils.py::test_a_token_path_is_never_passed_to_a_shell
FAILED tests/test_utils.py::test_a_missing_token_file_is_not_silently_empty
FAILED tests/test_utils.py::test_token_surroundings_are_stripped[tok\n]
FAILED tests/test_utils.py::test_token_surroundings_are_stripped[  tok\r\n]
FAILED tests/test_utils.py::test_each_request_carries_the_current_token
FAILED tests/test_utils.py::test_an_empty_or_blank_token_is_refused[]
FAILED tests/test_utils.py::test_an_empty_or_blank_token_is_refused[ ]
FAILED tests/test_utils.py::test_an_empty_or_blank_token_is_refused[\n]
FAILED tests/test_utils.py::test_an_empty_or_blank_token_is_refused[\r\n]
FAILED tests/test_utils.py::test_an_empty_or_blank_token_is_refused[ \t \r\n]
FAILED tests/test_utils.py::test_a_token_with_internal_whitespace_is_refused[tok en]
FAILED tests/test_utils.py::test_a_token_with_internal_whitespace_is_refused[tok\nen]
FAILED tests/test_utils.py::test_a_token_with_internal_whitespace_is_refused[tok\ten]
FAILED tests/test_utils.py::test_an_invalid_token_stops_before_any_request_is_made
FAILED tests/test_utils.py::test_create_package_variant_refreshes_the_token_between_get_and_post
15 failed, 148 passed in 1.28s
```

The sixth, `test_token_surroundings_are_stripped[tok]`, passes under both, which is correct: a token with nothing around it needs no stripping.

The rotation test is the one the old shape made impossible to write. It changes the file between two requests and reads back what actually went out:

```python
    get_capi_cluster(NAME, NAMESPACE)
    token_file.write_text("second")
    get_capi_cluster(NAME, NAMESPACE)

    sent = [call.request.headers["Authorization"] for call in responses.calls]
    assert sent == ["Bearer first", "Bearer second"]
```

The injection test's payload only ever writes inside pytest's `tmp_path`, and asserts both that the read fails and that the marker was not created.

`flake8 controllers/utils.py` reports 18 findings on `main` and 17 here; all are pre-existing `E501`s and the patch adds none. As with #1169, `.prow.yaml` never runs `tox` and the root `make unit` only walks directories containing a `go.mod`, so none of this runs in CI today — the runs above are local against the pinned `requirements.txt`.

### What review changed

Two defects survived the first version, and the second one was hiding the first:

- **An empty or blank token file still produced `Authorization: Bearer `** — the exact failure this PR claims to remove, moved from "`cat` failed" to "the file is there and empty". `read_token` now refuses an empty result, and refuses a token containing internal whitespace, which `http.client` would reject on the wire anyway.
- **The autouse fixture created an empty token file.** Every pre-existing request test therefore ran with `Bearer `, and none of them asserted the header, so the passing count proved nothing about token handling. The fixture now writes a real token through `monkeypatch` — which also stops it leaving `TOKEN` pointing at a deleted path after the module finishes — and one existing request test now pins the header value.

Four more came out of testing the code against what it actually talks to rather than against its own assumptions:

- **The mounted CA was pinned to whatever endpoint this was pointed at.** `tls_verify` used the bundle at `/var/run/secrets/.../ca.crt` whenever it existed, so an operator in a pod with `KUBERNETES_BASE_URL` set to another API server had the cluster CA applied to a server that CA does not certify, and every request to it would fail. The bundle now follows the address: the cluster serves its API at the advertised host and at `https://kubernetes.default.svc`, and anything else keeps the roots `requests` ships with. `tls_verify` takes the resolved address for this reason. The FOCOM sibling had the same defect and takes the same rule.
- **The validated host was not always the host connected to.** Comparing `validate_api_server_url` against what `requests` resolves, rather than reading either, turned up three disagreements: `urlsplit` drops a tab inside the authority and keeps a NUL, while `requests` percent-encodes both.

  ```
  'https://good.example\t.evil'   validator saw 'good.example.evil'
                                  requests    saw 'good.example%09.evil'
  ```

  Control characters and port zero are now refused. Endpoints are also compared as TLS origins rather than as strings, so `https://10.96.0.1` and `https://10.96.0.1:443` — one endpoint with one certificate, as are the two spellings of an IPv6 address and any casing of a DNS name — no longer take different trust paths. Four such forms were being sent to the public roots; that fails closed on a private-CA cluster rather than weakening anything, but it fails a configuration that is correct. `KUBERNETES_BASE_URL` is operator configuration rather than attacker input, so this is not an escalation, but a client that carries a bearer token should refuse an address it cannot agree on. The Go validator was measured the same way and already agrees with `net/http`, which rejects these at parse time.

- **Only one of the four API calls had its TLS setting pinned.** Deleting `verify=TLS_VERIFY` from any of the other three left the suite green — not a state a security invariant should be able to reach. Every call site is now exercised and asserted on both `verify` and `Authorization`; all eight deletions fail.

- **Test collection depended on the pod it ran in.** This module resolves the address and the bundle at import, so a fixture cannot undo an ambient setting: by the time one runs, the test module has already imported the package. `tests/conftest.py` clears it first, because pytest loads conftest before test modules. It matters because the kubelet injects `KUBERNETES_SERVICE_HOST` even when `automountServiceAccountToken` is false, so #1175's CI pod looks like a cluster with no CA. Running pytest directly under those variables failed collection before, and passes after. tox happens to filter them out, so #1175 was already green — incidental, and now not relied on.

- **A rollout window across two repositories.** My earlier claim that this has no effect on a healthy pod was too strong. Catalog releases set `KUBERNETES_BASE_URL=https://kubernetes.default.svc`, which [Kubernetes does not guarantee a serving certificate for](https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/), and that value cannot be removed in this commit because it lives in nephio-project/catalog. The postsubmit publishes this code as `:latest` the moment it merges, so between here and catalog#146 a pod can run the new image with the old package. In a pod, that exact value now resolves to the advertised address with a warning — the same server, named the way Kubernetes certifies it. Any other endpoint, any path, and anything outside a pod is untouched. The FOCOM sibling needs no such bridge, because its manifests are in this repository and change in the same commit.

  Worth flagging separately for whoever merges: the catalog pins `:latest` with `imagePullPolicy: IfNotPresent`, so merging this does not by itself replace the image on a node that already cached one. catalog#146 pinning an immutable tag is what actually rolls the fix out.

- **A fourth parser differential, and a corpus that stops the guessing.** `urlsplit` keeps a backslash inside the authority; `requests` hands the authority to urllib3, which reads it as a path separator:

  ```
  'https://10.96.0.1\proxy'   validator saw host '10.96.0.1\proxy'
                              requests prepared  'https://10.96.0.1/%5Cproxy'
                              and connects to    '10.96.0.1'
  ```

  A raw space differs the same way. So rather than name a third character, I fuzzed the validator against `requests`. Of ten thousand generated urls it accepted twelve hundred, and **four hundred and thirty two of those were addresses requests reads differently** — two whole classes I had not found by inspection:

  ```
  'https://10.96.0.1%2eevil.example'
      validator saw host '10.96.0.1%2eevil.example'
      requests decoded   '10.96.0.1.evil.example'      # a different name entirely

  'https://10.0.0.1。evil'
      accepted, and requests cannot prepare it at all
  ```

  The first is the worse one: the host that was checked is not a prefix of the host connected to, it is a different host. Refusing characters by name had now failed three times, so the host has to be a *shape* both parsers agree on instead — an IP literal, or a DNS name of letter-digit-hyphen labels. Percent escapes, backslashes, spaces and anything non-ASCII fall outside it, which is why the separate backslash and whitespace branches are gone rather than added to.

  The same corpus now has no disagreements, and neither does a random one: of **two hundred thousand** urls over an alphabet including unicode separators and full-width lookalikes, fourteen thousand are accepted and none prepares to a different origin. Every accepted url in the committed corpus is also asserted against `requests.Request(...).prepare()`, so a parser change in a dependency fails the suite rather than sending a token somewhere unchecked.

Rotation coverage was also too narrow: it only exercised `get_capi_cluster`. The production path does a GET and then a POST inside `create_package_variant`, so there is now a test that rotates the file between those two and asserts the second request carries the new token.

### What this does not cover

To be precise about the boundary: this fixes the TLS default, which endpoint is trusted and which bundle is used for it, and how the token is acquired and rotated. Request timeouts, redirect policy, ambient proxy trust and how configuration errors are classified into conditions are #1174, and the Kubernetes response shape that `check_o2ims_provisioning_request` assumes is #1177. Both touch `utils.py` and will need a rebase after this.

### Effect on existing deployments

None in a healthy pod: the token file is there and is now read per request instead of once. A deployment that was running on an empty token was already failing every call with 401 and now gets a `FileNotFoundError` naming the path it could not read, which is the same outage with a usable message.

`HEADERS_DICT` is replaced by `BASE_HEADERS` plus `request_headers()`. Nothing outside `controllers/utils.py` referenced it. The autouse fixture in `tests/test_utils.py` that sets `TOKEN` to a temporary file starts having an effect for the first time; it previously ran after the module had already been imported and read.

### Notes for maintainers

- This is now stacked on #1169 rather than forked beside it. The two branches previously shared a base and replaced the same block, so each head still contained the defect the other fixed; resolving that by hand later is exactly where `HTTPS_VERIFY` or `os.popen` could have come back. The merge is asserted, not assumed: the resolution checks that no `os.popen`, `disable_warnings`, `bool(os.getenv("HTTPS_VERIFY"` or `127.0.0.1:8080` survives, and that all four call sites carry both `request_headers()` and `TLS_VERIFY`.
- Requests still have no timeout, and a token failure is flattened into `status=False` which `cluster_creation_request` reports as `progressing` before a 30-minute generic timeout — so the clear error this PR produces can still reach the user as a slow timeout. Raised as #1174 rather than folded in here.
- Release triage is yours. The change is confined to the o2ims operator's API client and its tests.
- `SECURITY.md` asks that vulnerabilities not be reported through public issues. I have not opened a public issue for it. Say the word and I will route it through sig-security@lists.nephio.org before this goes further.





