### PR TITLE
[network] Register the Node handler on Node, not Endpoint

### DIFF
--- a/controllers/pkg/reconcilers/network/reconciler.go
+++ b/controllers/pkg/reconcilers/network/reconciler.go
@@ -52,7 +52,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 func init() {
@@ -77,6 +80,7 @@ const (
 //+kubebuilder:rbac:groups=config.resource.nephio.org,resources=networks/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=inv.nephio.org,resources=endpoints,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=inv.nephio.org,resources=endpoints/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=inv.nephio.org,resources=nodes,verbs=get;list;watch
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, c interface{}) (map[schema.GroupVersionKind]chan event.GenericEvent, error) {
@@ -116,7 +120,12 @@ func (r *reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, c i
 		Owns(&vlanv1alpha1.VLANIndex{}).
 		Owns(&configv1alpha1.Network{}).
 		Watches(&invv1alpha1.Endpoint{}, &endpointEventHandler{client: mgr.GetClient()}).
-		Watches(&invv1alpha1.Endpoint{}, &nodeEventHandler{client: mgr.GetClient()}).
+		// WatchesRawSource with a typed source rather than Watches: source.Kind
+		// binds the watched object and the handler to one type parameter, so
+		// pairing this handler with another Kind stops compiling. Pairing them
+		// by hand is how every Node event ended up being discarded.
+		WatchesRawSource(source.Kind(mgr.GetCache(), &invv1alpha1.Node{},
+			handler.TypedEventHandler[*invv1alpha1.Node, reconcile.Request](&nodeEventHandler{client: mgr.GetClient()}))).
 		Complete(r)
 
 }

--- a/controllers/pkg/reconcilers/network/watch_node.go
+++ b/controllers/pkg/reconcilers/network/watch_node.go
@@ -33,44 +33,73 @@ type nodeEventHandler struct {
 	client client.Client
 }
 
-func (e *nodeEventHandler) Create(ctx context.Context, evt event.TypedCreateEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	e.add(ctx, evt.Object, q)
+func (e *nodeEventHandler) Create(ctx context.Context, evt event.TypedCreateEvent[*invv1alpha1.Node], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	e.enqueue(ctx, q, evt.Object)
 }
 
-func (e *nodeEventHandler) Update(ctx context.Context, evt event.TypedUpdateEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	e.add(ctx, evt.ObjectOld, q)
-	e.add(ctx, evt.ObjectNew, q)
+func (e *nodeEventHandler) Update(ctx context.Context, evt event.TypedUpdateEvent[*invv1alpha1.Node], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	// Both sides: a Node that moves between topologies has to wake the Network
+	// it left as well as the one it joined.
+	e.enqueue(ctx, q, evt.ObjectOld, evt.ObjectNew)
 }
 
-func (e *nodeEventHandler) Delete(ctx context.Context, evt event.TypedDeleteEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	e.add(ctx, evt.Object, q)
+func (e *nodeEventHandler) Delete(ctx context.Context, evt event.TypedDeleteEvent[*invv1alpha1.Node], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	e.enqueue(ctx, q, evt.Object)
 }
 
-func (e *nodeEventHandler) Generic(ctx context.Context, evt event.TypedGenericEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	e.add(ctx, evt.Object, q)
+func (e *nodeEventHandler) Generic(ctx context.Context, evt event.TypedGenericEvent[*invv1alpha1.Node], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	e.enqueue(ctx, q, evt.Object)
 }
 
-func (e *nodeEventHandler) add(ctx context.Context, obj client.Object, queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	cr, ok := obj.(*invv1alpha1.Node)
-	if !ok {
+// enqueue wakes every Network whose topology one of these Nodes belongs to.
+//
+// The Nodes are taken together rather than one at a time. An update carries
+// two, and listing per Node would scan the cache twice and add each matching
+// Network twice: the queue only folds those into one reconcile while no worker
+// picks the first up in between, which is not something a handler can rely on.
+func (e *nodeEventHandler) enqueue(ctx context.Context, queue workqueue.TypedRateLimitingInterface[reconcile.Request], nodes ...*invv1alpha1.Node) {
+	log := log.FromContext(ctx)
+
+	topologies := map[string]struct{}{}
+	for _, node := range nodes {
+		if node == nil {
+			continue
+		}
+		log.Info("event", "kind", node.GetObjectKind(), "name", node.GetName())
+
+		labels := node.GetLabels()
+		if labels[invv1alpha1.NephioProviderKey] != nokiaSRLProvider {
+			continue
+		}
+		// Absent, not empty. A map lookup gives "" for both, but a label set
+		// to "" is a topology as far as the reconciler is concerned: it lists
+		// Nodes with MatchingLabels, which selects that value and not the
+		// missing key. Treating the two alike here would leave a Network whose
+		// topology is empty asleep through changes to its own Nodes.
+		topology, present := labels[invv1alpha1.NephioTopologyKey]
+		if !present {
+			continue
+		}
+		topologies[topology] = struct{}{}
+	}
+	if len(topologies) == 0 {
 		return
 	}
-	log := log.FromContext(ctx)
-	log.Info("event", "kind", obj.GetObjectKind(), "name", cr.GetName())
 
 	networks := &infrav1alpha1.NetworkList{}
 	if err := e.client.List(ctx, networks); err != nil {
+		log.Error(err, "cannot list networks, event dropped")
 		return
 	}
 
-	for _, network := range networks.Items {
-		// only enqueue if the provider and the network topology match
-		if cr.Labels[invv1alpha1.NephioProviderKey] == nokiaSRLProvider &&
-			cr.Labels[invv1alpha1.NephioTopologyKey] == network.Spec.Topology {
-			log.Info("event requeue network", "name", network.GetName())
-			queue.Add(reconcile.Request{NamespacedName: types.NamespacedName{
-				Namespace: network.GetNamespace(),
-				Name:      network.GetName()}})
+	for i := range networks.Items {
+		network := &networks.Items[i]
+		if _, ok := topologies[network.Spec.Topology]; !ok {
+			continue
 		}
+		log.Info("event requeue network", "name", network.GetName())
+		queue.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+			Namespace: network.GetNamespace(),
+			Name:      network.GetName()}})
 	}
 }

--- a/controllers/pkg/reconcilers/network/watch_node_test.go
+++ b/controllers/pkg/reconcilers/network/watch_node_test.go
@@ -1,0 +1,268 @@
+/*
+Copyright 2026 The Nephio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"context"
+	"testing"
+
+	infrav1alpha1 "github.com/nephio-project/api/infra/v1alpha1"
+	invv1alpha1 "github.com/nokia/k8s-ipam/apis/inv/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	testTopology  = "topology-a"
+	otherTopology = "topology-b"
+)
+
+// testNetwork returns a Network bound to the given topology.
+func testNetwork(namespace, name, topology string) *infrav1alpha1.Network {
+	return &infrav1alpha1.Network{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec:       infrav1alpha1.NetworkSpec{Topology: topology},
+	}
+}
+
+// testNode returns a Node carrying the labels the handler matches on.
+func withoutTopologyLabel(node *invv1alpha1.Node) *invv1alpha1.Node {
+	delete(node.Labels, invv1alpha1.NephioTopologyKey)
+	return node
+}
+
+func testNode(provider, topology string) *invv1alpha1.Node {
+	return &invv1alpha1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "inventory",
+			Name:      "node-1",
+			Labels: map[string]string{
+				invv1alpha1.NephioProviderKey: provider,
+				invv1alpha1.NephioTopologyKey: topology,
+			},
+		},
+	}
+}
+
+// testRequest returns the reconcile.Request a Network is expected to produce.
+func testRequest(namespace, name string) reconcile.Request {
+	return reconcile.Request{NamespacedName: types.NamespacedName{
+		Namespace: namespace, Name: name}}
+}
+
+// drainQueue returns everything the handler enqueued, without blocking on an
+// empty queue.
+func drainQueue(q workqueue.TypedRateLimitingInterface[reconcile.Request]) []reconcile.Request {
+	requests := make([]reconcile.Request, 0, q.Len())
+	for q.Len() > 0 {
+		item, shutdown := q.Get()
+		if shutdown {
+			break
+		}
+		requests = append(requests, item)
+		q.Done(item)
+	}
+	return requests
+}
+
+// TestNodeEventHandler covers which Node changes enqueue which Networks.
+//
+// There is no case for an object of another kind: the handler is typed on
+// *invv1alpha1.Node and registered through source.Kind, so the mispairing that
+// caused this bug no longer compiles and cannot be reached at runtime.
+// countingClient records how many times the handler scans the cache. A per-Node
+// list would be invisible in the requests alone, since the queue folds the
+// duplicates away while nothing is consuming it.
+type countingClient struct {
+	client.Client
+	lists int
+}
+
+func (c *countingClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	c.lists++
+	return c.Client.List(ctx, list, opts...)
+}
+
+func TestNodeEventHandler(t *testing.T) {
+	// bothTopologies is used by the migration cases, which need a Network on
+	// each side of the move.
+	bothTopologies := []*infrav1alpha1.Network{
+		testNetwork("ns-a", "network-a", testTopology),
+		testNetwork("ns-b", "network-b", otherTopology),
+	}
+
+	cases := map[string]struct {
+		node     *invv1alpha1.Node
+		previous *invv1alpha1.Node // when set, delivered as an update previous -> node
+		deleted  bool              // when set, delivered as a delete of node
+		networks []*infrav1alpha1.Network
+		expected []reconcile.Request
+		// expectedLists is 0 when no Node carries an eligible topology: there
+		// is nothing to match, so the cache is never scanned.
+		expectedLists int
+	}{
+		"matching provider and topology": {
+			node:          testNode(nokiaSRLProvider, testTopology),
+			expected:      []reconcile.Request{testRequest("ns-a", "network-a")},
+			expectedLists: 1,
+		},
+		"other provider": {
+			node: testNode("other.vendor.com", testTopology),
+		},
+		"other topology": {
+			node:          testNode(nokiaSRLProvider, otherTopology),
+			expectedLists: 1,
+		},
+		// Absent and empty are different labels. testNode always sets the key,
+		// so the absent case has to remove it.
+		"provider but the topology label is absent": {
+			node:     withoutTopologyLabel(testNode(nokiaSRLProvider, testTopology)),
+			networks: []*infrav1alpha1.Network{testNetwork("ns-a", "network-a", "")},
+		},
+		"an explicitly empty topology matches an empty-topology Network": {
+			node:          testNode(nokiaSRLProvider, ""),
+			networks:      []*infrav1alpha1.Network{testNetwork("ns-a", "network-a", "")},
+			expected:      []reconcile.Request{testRequest("ns-a", "network-a")},
+			expectedLists: 1,
+		},
+		"moving out of the empty topology wakes both sides": {
+			previous:      testNode(nokiaSRLProvider, ""),
+			node:          testNode(nokiaSRLProvider, testTopology),
+			networks:      []*infrav1alpha1.Network{testNetwork("ns-a", "network-a", ""), testNetwork("ns-b", "network-b", testTopology)},
+			expected:      []reconcile.Request{testRequest("ns-a", "network-a"), testRequest("ns-b", "network-b")},
+			expectedLists: 1,
+		},
+		"moving into the empty topology wakes both sides": {
+			previous:      testNode(nokiaSRLProvider, testTopology),
+			node:          testNode(nokiaSRLProvider, ""),
+			networks:      []*infrav1alpha1.Network{testNetwork("ns-a", "network-a", ""), testNetwork("ns-b", "network-b", testTopology)},
+			expected:      []reconcile.Request{testRequest("ns-a", "network-a"), testRequest("ns-b", "network-b")},
+			expectedLists: 1,
+		},
+		"no labels": {
+			node: &invv1alpha1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+		},
+		"every matching network, namespace and name intact": {
+			node: testNode(nokiaSRLProvider, testTopology),
+			networks: []*infrav1alpha1.Network{
+				testNetwork("ns-a", "network-a", testTopology),
+				testNetwork("ns-b", "network-b", testTopology),
+				testNetwork("ns-c", "network-c", otherTopology),
+			},
+			expected: []reconcile.Request{
+				testRequest("ns-a", "network-a"),
+				testRequest("ns-b", "network-b"),
+			},
+			expectedLists: 1,
+		},
+		// A Node leaving the inventory has to wake its Network so the config
+		// rendered from it stops referring to a node that is gone.
+		"a deleted Node wakes its Network": {
+			node:          testNode(nokiaSRLProvider, testTopology),
+			deleted:       true,
+			expected:      []reconcile.Request{testRequest("ns-a", "network-a")},
+			expectedLists: 1,
+		},
+		"a deleted Node of another provider wakes nothing": {
+			node:    testNode("other.vendor.com", testTopology),
+			deleted: true,
+		},
+		"a deleted Node in the empty topology wakes its Network": {
+			node:          testNode(nokiaSRLProvider, ""),
+			deleted:       true,
+			networks:      []*infrav1alpha1.Network{testNetwork("ns-a", "network-a", "")},
+			expected:      []reconcile.Request{testRequest("ns-a", "network-a")},
+			expectedLists: 1,
+		},
+		"an unchanged update enqueues each Network once": {
+			node:          testNode(nokiaSRLProvider, testTopology),
+			previous:      testNode(nokiaSRLProvider, testTopology),
+			expected:      []reconcile.Request{testRequest("ns-a", "network-a")},
+			expectedLists: 1,
+		},
+		"moving between topologies wakes the Network left and the one joined": {
+			previous: testNode(nokiaSRLProvider, testTopology),
+			node:     testNode(nokiaSRLProvider, otherTopology),
+			networks: bothTopologies,
+			expected: []reconcile.Request{
+				testRequest("ns-a", "network-a"),
+				testRequest("ns-b", "network-b"),
+			},
+			expectedLists: 1,
+		},
+		"losing the provider label still wakes the Network left behind": {
+			previous:      testNode(nokiaSRLProvider, testTopology),
+			node:          testNode("other.vendor.com", testTopology),
+			expected:      []reconcile.Request{testRequest("ns-a", "network-a")},
+			expectedLists: 1,
+		},
+		"gaining the provider label wakes the Network joined": {
+			previous:      testNode("other.vendor.com", testTopology),
+			node:          testNode(nokiaSRLProvider, testTopology),
+			expected:      []reconcile.Request{testRequest("ns-a", "network-a")},
+			expectedLists: 1,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, infrav1alpha1.AddToScheme(scheme))
+			require.NoError(t, invv1alpha1.AddToScheme(scheme))
+
+			networks := tc.networks
+			if networks == nil {
+				networks = []*infrav1alpha1.Network{
+					testNetwork("ns-a", "network-a", testTopology)}
+			}
+			objects := make([]client.Object, 0, len(networks))
+			for _, network := range networks {
+				objects = append(objects, network)
+			}
+
+			counting := &countingClient{Client: fake.NewClientBuilder().
+				WithScheme(scheme).WithObjects(objects...).Build()}
+			handler := &nodeEventHandler{client: counting}
+			queue := workqueue.NewTypedRateLimitingQueue(
+				workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+
+			switch {
+			case tc.previous != nil:
+				handler.Update(context.Background(),
+					event.TypedUpdateEvent[*invv1alpha1.Node]{
+						ObjectOld: tc.previous, ObjectNew: tc.node}, queue)
+			case tc.deleted:
+				handler.Delete(context.Background(),
+					event.TypedDeleteEvent[*invv1alpha1.Node]{Object: tc.node}, queue)
+			default:
+				handler.Create(context.Background(),
+					event.TypedCreateEvent[*invv1alpha1.Node]{Object: tc.node}, queue)
+			}
+
+			assert.ElementsMatch(t, tc.expected, drainQueue(queue))
+			assert.Equal(t, tc.expectedLists, counting.lists, "cache scans")
+		})
+	}
+}


### PR DESCRIPTION
The network controller sets up two watches on the same type:

```go
		Watches(&invv1alpha1.Endpoint{}, &endpointEventHandler{client: mgr.GetClient()}).
		Watches(&invv1alpha1.Endpoint{}, &nodeEventHandler{client: mgr.GetClient()}).
```

`nodeEventHandler.add` opens with a type assertion and returns quietly when it fails:

```go
	cr, ok := obj.(*invv1alpha1.Node)
	if !ok {
		return
	}
```

Everything the second watch delivers is an `Endpoint`, so that assertion has never once succeeded and no Node change has ever enqueued a Network.

The reconciler does read Node state, on every pass, through `getProviderNodes`, filtered on the same labels the handler checks:

```go
	opts := []client.ListOption{
		client.MatchingLabels{
			invv1alpha1.NephioProviderKey: nokiaSRLProvider,
			invv1alpha1.NephioTopologyKey: topology,
		},
	}
```

So the data is consumed and never watched. A node joining or leaving a topology, or having its provider or topology label changed, gets picked up only when something else happens to trigger a reconcile: a Network write, an Endpoint event, one of the owned `NetworkInstance`/`VLANIndex`/`Network` resources. Between those, the rendered device config describes a topology that is no longer there.

Registering the handler against `Node` is the fix. I bound the pair through a type parameter as well, so this particular mistake cannot come back:

```go
		WatchesRawSource(source.Kind(mgr.GetCache(), &invv1alpha1.Node{},
			handler.TypedEventHandler[*invv1alpha1.Node, reconcile.Request](&nodeEventHandler{client: mgr.GetClient()}))).
```

`source.Kind` takes the watched object and the handler through one parameter, so pointing this at `Endpoint` again stops compiling:

```console
$ go build ./reconcilers/network/
reconcilers/network/reconciler.go:128:4: in call to source.Kind, type
handler.TypedEventHandler[*inv/v1alpha1.Node, reconcile.Request] ... does not match
inferred type handler.TypedEventHandler[*inv/v1alpha1.Endpoint, reconcile.Request]
```

The handler is typed on `*invv1alpha1.Node` throughout now, so the assertion that swallowed every event is gone and a failed `List` gets logged instead of vanishing. The RBAC marker for nodes was missing too, on a resource this controller lists and now watches.

## Two things I had wrong in the first version

An absent label and an empty one are not the same label, and I was treating them as one. The first version read the topology with a plain map lookup and skipped anything that came back `""`. Kubernetes allows a label set to the empty string, and `Network.spec.topology` is required but has no `minLength`, so `topology: ""` is a value the schema accepts. The reconciler already treats it as one, because `MatchingLabels` selects on the value rather than on the key existing. I checked with a fake client:

```console
    sel_probe_test.go:39: selector topology="" matched 1: [empty-value]
```

`label-absent` is the other object in that client and it does not come back. So a Network with an empty topology was consuming Nodes this handler would never have woken it for, which is the same staleness this PR is about, one level down. The two-value lookup separates them.

The other one is the update path. It called the handler body once per side, which scans the whole Network cache twice and calls `queue.Add` twice for each match, and I claimed the workqueue folded the second Add away. That only holds while nothing is consuming the queue, which is the situation a test that drains afterwards creates and not one a handler can rely on:

```go
q.Add(req)           // first side
item, _ := q.Get()   // a worker picks it up mid-handler
q.Add(req)           // second side: item is processing, so this only sets the dirty bit
q.Done(item)         // Done sees dirty and queues it again  ->  len 1
```

Both cases end at length 1 against `client-go`'s queue, but the interleaved one has already handed an item out, so it is two reconciles and not one. `Update` now collects the eligible topologies from both sides, scans once, and enqueues the union. An update between two Nodes of some other provider returns without listing at all. A second scan is invisible in the resulting requests while nothing consumes the queue, so the tests assert the scan count as well.

## On `make manifests`

I did not run it. The target lives in `operators/nephio-controller-manager` and runs `controller-gen ... paths="./..."`, and that module contains one package:

```console
$ cd operators/nephio-controller-manager && go list ./...
github.com/nephio-project/nephio/operators/nephio-controller-manager
```

The reconcilers are a separate module pulled in as a blank import, so `./...` never reaches them. That operator also has no `config/` directory, so there is no generated role to refresh; running the target would create one from nothing. And `grep -rl networkinstances --include='*.yaml' .` is empty, which says the existing markers have never been generated into anything in this repository either.

The ClusterRole that is actually deployed is hand-maintained in `nephio-project/catalog` at `nephio/core/nephio-operator/app/controller/clusterrole-network.yaml`, and it already grants `nodes`:

```yaml
- apiGroups:
  - inv.nephio.org
  resources:
  - links
  - nodes
  - endpoints
```

So the marker closes a gap between what the code declares and what it needs, and nothing deployed changes. Say the word if you would rather I run the target anyway and commit whatever falls out.

## Proof manifests

```console
$ go test ./reconcilers/network -count=1 -v
--- PASS: TestNodeEventHandler (0.11s)
    --- PASS: TestNodeEventHandler/matching_provider_and_topology (0.00s)
    --- PASS: TestNodeEventHandler/other_provider (0.00s)
    --- PASS: TestNodeEventHandler/other_topology (0.00s)
    --- PASS: TestNodeEventHandler/no_labels (0.00s)
    --- PASS: TestNodeEventHandler/every_matching_network,_namespace_and_name_intact (0.00s)
    --- PASS: TestNodeEventHandler/provider_but_the_topology_label_is_absent (0.08s)
    --- PASS: TestNodeEventHandler/an_explicitly_empty_topology_matches_an_empty-topology_Network (0.00s)
    --- PASS: TestNodeEventHandler/moving_between_topologies_wakes_the_Network_left_and_the_one_joined (0.00s)
    --- PASS: TestNodeEventHandler/moving_out_of_the_empty_topology_wakes_both_sides (0.00s)
    --- PASS: TestNodeEventHandler/moving_into_the_empty_topology_wakes_both_sides (0.00s)
    --- PASS: TestNodeEventHandler/losing_the_provider_label_still_wakes_the_Network_left_behind (0.00s)
    --- PASS: TestNodeEventHandler/gaining_the_provider_label_wakes_the_Network_joined (0.00s)
    --- PASS: TestNodeEventHandler/an_unchanged_update_enqueues_each_Network_once (0.00s)
    --- PASS: TestNodeEventHandler/a_deleted_Node_wakes_its_Network (0.00s)
    --- PASS: TestNodeEventHandler/a_deleted_Node_of_another_provider_wakes_nothing (0.00s)
    --- PASS: TestNodeEventHandler/a_deleted_Node_in_the_empty_topology_wakes_its_Network (0.00s)
ok  	github.com/nephio-project/nephio/controllers/pkg/reconcilers/network	0.479s

$ make -C controllers/pkg unit
ok  	github.com/nephio-project/nephio/controllers/pkg/reconcilers/network	0.427s	coverage: 10.3% of statements
# 15 packages ok, 0 FAIL

$ make -C controllers/pkg lint
0 issues.

$ git diff --check
```

The package had no test file before this, which is where the 0% it started from comes from.

A green table does not say much on its own, so each case was run against the change it is supposed to catch. Removing the provider check fails `other provider`. Removing the topology check fails `other topology` and `every matching network`. Dropping `ObjectOld` fails both migration cases. Going back to the single-value label lookup fails the four empty-topology cases. Restoring the per-Node `List` fails the scan counts. Making `Delete` a no-op fails the two delete cases.

The registration itself is guarded by the compiler rather than a test, which I think is the stronger of the two: `Builder.Watches` takes `client.Object` and an untyped handler so it accepts any pairing, and no unit test can inspect what a built controller ended up watching without standing up a manager and a cache.

## Release triage and docs

Triage is yours to set. The change is confined to one reconciler in `controllers/pkg` and adds no API surface, so I do not think it needs a `nephio-project/docs` change; I searched that repo for the Node watch and the network reconciler and found nothing that describes this behaviour. Happy to raise one if you disagree.

## Housekeeping

This does not touch the shared mutable reconciliation state (`r.devices`) that #1082 deals with. The two overlap mechanically, same reconciler and probably conflicting diffs, but neither is a prerequisite for the other today: nothing passes `MaxConcurrentReconciles` to this builder, so controller-runtime's default of 1 applies (`controller.go:245`) and there is a single worker. If concurrency is turned on here later, #1082's fix becomes necessary for correctness.

`watch_endpoint.go` still has the untyped shape, the runtime assertion, the double list and the same absent-versus-empty confusion. I raised that as #1180 rather than growing this PR; two people have picked it up since, so it is worth landing this one before their work diverges from it.

A Node update still scans the cached Network list once per event. A typed predicate that ignores status-only changes would avoid even that if Node churn grows, but that is its own change.
