### PR TITLE
Run the o2ims Python tests in CI

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -29,6 +29,38 @@ presubmits:
         - make
         args:
         - gosec
+  # The path filter includes this file so the job runs on changes to its own
+  # definition; otherwise a change here can only prove that the YAML parses.
+  - name: presubmit-nephio-o2ims-python-test
+    decorate: true
+    always_run: false
+    run_if_changed: '(^operators/o2ims-operator/|^\.prow\.yaml$)'
+    spec:
+      # This runs test code from the pull request and never talks to the build
+      # cluster API, so it should not be handed that cluster's credential. It
+      # also keeps the run hermetic: the operator reads the standard token path
+      # at import time.
+      automountServiceAccountToken: false
+      containers:
+      # The image the operator is built from, so the tests exercise the same
+      # interpreter, musl and OpenSSL that ship. tox is pinned because an
+      # unpinned install makes the gate depend on whenever it last ran.
+      - image: python:3.12.10-alpine3.21
+        command:
+        - "/bin/sh"
+        - "-c"
+        - |
+          set -eu
+          # The kubelet injects these even with automountServiceAccountToken
+          # false, and the operator reads them at import to decide it is in a
+          # cluster. Unit tests are not, and this pod deliberately has no CA.
+          unset KUBERNETES_SERVICE_HOST KUBERNETES_SERVICE_PORT \
+                KUBERNETES_BASE_URL KUBERNETES_CA_FILE \
+                UNSAFE_SKIP_TLS_VERIFY HTTPS_VERIFY \
+                REQUESTS_CA_BUNDLE CURL_CA_BUNDLE TOKEN
+          cd operators/o2ims-operator
+          python -m pip install --no-cache-dir tox==4.60.0
+          python -m tox -e py312
   - name: presubmit-nephio-license-header-check
     decorate: true
     always_run: false

--- a/operators/o2ims-operator/tox.ini
+++ b/operators/o2ims-operator/tox.ini
@@ -5,7 +5,6 @@ envlist = py311, py312, lint
 deps =
     -r requirements.txt
     -r tests/unit_test_requirements.txt
-    pytest-cov
 commands =
     pytest --maxfail=1 --disable-warnings -q -v
 


### PR DESCRIPTION
Nothing under `operators/o2ims-operator` is executed by CI today.

The Prow presubmits invoke the root `make unit`, `make lint` and `make gosec`, and the root Makefile decides what to visit like this:

```make
GO_MOD_DIRS = $(shell find . -name 'go.mod' -exec sh -c 'echo \"$$(dirname "{}")\" ' \; )
```

The o2ims operator has no `go.mod`, so it is never visited. Its `tox.ini` declares `py311`, `py312` and `lint` environments and `tests/test_utils.py` holds 39 tests, but all of that runs only on a contributor's machine. A regression test added there — including the ones in #1170 — protects nothing after the pull request is merged.

### What this adds

```yaml
  - name: presubmit-nephio-o2ims-python-test
    decorate: true
    always_run: false
    run_if_changed: '(^operators/o2ims-operator/|^\.prow\.yaml$)'
    spec:
      automountServiceAccountToken: false
      containers:
      - image: python:3.12.10-alpine3.21
        command:
        - "/bin/sh"
        - "-c"
        - |
          set -eu
          unset KUBERNETES_SERVICE_HOST KUBERNETES_SERVICE_PORT \
                KUBERNETES_BASE_URL KUBERNETES_CA_FILE \
                UNSAFE_SKIP_TLS_VERIFY HTTPS_VERIFY \
                REQUESTS_CA_BUNDLE CURL_CA_BUNDLE TOKEN
          cd operators/o2ims-operator
          python -m pip install --no-cache-dir tox==4.60.0
          python -m tox -e py312
```

Four choices worth stating:

**It runs tox rather than pip and pytest directly.** `tox.ini` already declares the dependency set and the exact pytest invocation. Spelling those out again would create a second list that drifts from the one contributors run; this way `tox -e py312` means the same thing locally and in CI, and the README's existing instructions stay true. `tox` itself is pinned, because an unpinned install makes the gate depend on whichever release happened to be current.

**No build-cluster credential.** The job runs test code from the pull request and never calls the Kubernetes API, so `automountServiceAccountToken: false`. It also keeps the run hermetic: on `main` the operator reads the standard service account token path at import time.

**The service environment is cleared.** `automountServiceAccountToken: false` removes the projected volume; it does not remove the `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` that the kubelet injects for the default `kubernetes` service. So a pod with no credentials still looks like a cluster to anything reading those two variables — and #1170 reads them at import, to decide which CA bundle to trust. With no `ca.crt` to find, that raises before pytest can collect:

```console
$ env KUBERNETES_SERVICE_HOST=10.96.0.1 KUBERNETES_SERVICE_PORT=443 pytest -q
E   RuntimeError: the in-cluster CA /var/run/secrets/kubernetes.io/serviceaccount/ca.crt is missing
!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!
```

That is not reachable through this job as written, because tox does not forward those variables by default — but that is a property of tox's `passenv`, not of anything stated here, and a job that called pytest directly would fail. #1170 now carries a `tests/conftest.py` that clears the ambient configuration before test modules are imported, which is where the fix belongs; the `unset` here is the second layer. Reverting either one alone still passes, which is the point of having both.

**The image is the one the operator is built from** (`Dockerfile` uses `python:3.12.10-alpine3.21`), so the tests exercise the same interpreter, musl and OpenSSL that ship. That matters here, because what these tests cover is TLS verification and CA bundle handling — a Debian image would test a different OpenSSL against a different trust store.

**The path filter includes this file,** so a change to the job definition runs the job. Without that, a pull request touching only `.prow.yaml` can prove the YAML parses and nothing else.

### Proof manifests

The job's script was run in that image, against an archive of the committed tree rather than a working directory that might carry untracked leftovers:

```console
$ git archive HEAD | tar -x -C /tmp/prow-sim
$ podman run --rm -v /tmp/prow-sim:/w -w /w python:3.12.10-alpine3.21 \
    sh -c 'set -eu; cd operators/o2ims-operator;
           python -m pip install --no-cache-dir tox==4.60.0;
           python -m tox -e py312'
tests/test_utils.py .......................................              [100%]
============================== 39 passed in 0.36s ==============================
  py312: OK (20.91=setup[19.96]+cmd[0.95] seconds)
exit: 0
```

A green run only shows the job reports; it does not show that it gates. With one deliberately failing test added to `tests/`, the same command exits non-zero:

```console
$ echo 'def test_deliberately_failing(): assert False' > tests/test_gate_check.py
$ podman run ... ; echo $?
1
```

`.prow.yaml` parses, and the job lands between the Go checks and the licensing ones:

```console
$ python3 -c "import yaml; print([j['name'] for j in yaml.safe_load(open('.prow.yaml'))['presubmits']])"
['presubmit-nephio-go-test', 'presubmit-nephio-golangci-lint', 'presubmit-nephio-gosec',
 'presubmit-nephio-o2ims-python-test', 'presubmit-nephio-license-header-check',
 'presubmit-nephio-scancode-toolkit', 'presubmit-nephio-fossology', 'presubmit-nephio-lichen']
```

The filter now includes `.prow.yaml`, so this pull request does exercise the job on itself once CI is enabled. Until an org member runs `/ok-to-test`, the evidence above is a local reproduction of the job's own script against the committed tree.

### Deliberately not included

- **Lint.** `flake8 controllers` reports findings across the package that predate this change, so making it a gate would fail every pull request until that debt is paid. It belongs in its own change, after the existing findings are dealt with.
- **A py311 job.** The operator ships on 3.12, so that is what CI checks. `tox.ini` also declares `py311`; if you want the matrix it describes, it is one more entry in this file.
- `tox.ini` installed `pytest-cov` while no command requested coverage. That is removed here rather than pinned, since the gate never used it.
- **Integration and e2e coverage.** This closes the unit-test half of #848 for one operator; the rest of that issue stands.

### Why now

#1170 is a security fix for this operator whose regression tests currently cannot run in CI, so its "163 passed" is local evidence only. Merging this first turns those tests into a merge gate rather than a claim in a pull request description.

It is independent of that change in the sense that matters for merging — it touches `.prow.yaml` and one unused line in `tox.ini`, and passes against `main` as it stands. It is *not* independent in behaviour, as the section above describes: #1170 changes what happens at import time inside the pod this job creates. The combined tree was run under the pod's variables, with no service-account volume mounted:

```console
$ podman run --rm -e KUBERNETES_SERVICE_HOST=10.96.0.1 -e KUBERNETES_SERVICE_PORT=443 \
    -v $PWD:/w -w /w python:3.12.10-alpine3.21 /bin/sh -c '<the script above>'
163 passed in 1.46s
  py312: OK
exit: 0
```


