### PR TITLE
[focom] Let the transport sign Porch requests

### DIFF
--- a/operators/focom-operator/Makefile
+++ b/operators/focom-operator/Makefile
@@ -141,7 +141,7 @@ unit-tests: fmt vet ## Run unit tests only (no external dependencies required).
 		./internal/nbi/models/ \
 		./internal/nbi/validation/
 	@go test -v -coverprofile=coverage-storage.out ./internal/nbi/storage/ \
-		-run "TestInMemory|TestCreateResourceYAML|TestParseResourceYAML|TestRoundTrip|TestExtractResourceID|TestGenerateWorkspaceName|TestSetResource|TestConvertTo|TestCreateKptfile"
+		-run "TestInMemory|TestCreateResourceYAML|TestParseResourceYAML|TestRoundTrip|TestExtractResourceID|TestGenerateWorkspaceName|TestSetResource|TestConvertTo|TestCreateKptfile|TestPorchStorageTLS"
 	@go test -v -coverprofile=coverage-controller.out \
 		./internal/controller/ -run TestValidateTemplateAlignment || echo "Controller tests skipped"
 	@echo ""
@@ -163,7 +163,7 @@ ci-tests: fmt vet ## Run the same tests as CI pipeline (unit tests only, fast ex
 		./internal/nbi/models/ \
 		./internal/nbi/validation/
 	@go test -v -coverprofile=coverage-storage.out ./internal/nbi/storage/ \
-		-run "TestInMemory|TestCreateResourceYAML|TestParseResourceYAML|TestRoundTrip|TestExtractResourceID|TestGenerateWorkspaceName|TestSetResource|TestConvertTo|TestCreateKptfile"
+		-run "TestInMemory|TestCreateResourceYAML|TestParseResourceYAML|TestRoundTrip|TestExtractResourceID|TestGenerateWorkspaceName|TestSetResource|TestConvertTo|TestCreateKptfile|TestPorchStorageTLS"
 	@go test -v -coverprofile=coverage-controller.out \
 		./internal/controller/ -run TestValidateTemplateAlignment || echo "Controller tests skipped"
 	@echo ""

--- a/operators/focom-operator/Makefile
+++ b/operators/focom-operator/Makefile
@@ -141,7 +141,7 @@ unit-tests: fmt vet ## Run unit tests only (no external dependencies required).
 		./internal/nbi/models/ \
 		./internal/nbi/validation/
 	@go test -v -coverprofile=coverage-storage.out ./internal/nbi/storage/ \
-		-run "TestInMemory|TestCreateResourceYAML|TestParseResourceYAML|TestRoundTrip|TestExtractResourceID|TestGenerateWorkspaceName|TestSetResource|TestConvertTo|TestCreateKptfile|TestPorchStorageTLS"
+		-run "TestInMemory|TestCreateResourceYAML|TestParseResourceYAML|TestRoundTrip|TestExtractResourceID|TestGenerateWorkspaceName|TestSetResource|TestConvertTo|TestCreateKptfile|TestPorchStorageTLS|TestPorchStorageAuth"
 	@go test -v -coverprofile=coverage-controller.out \
 		./internal/controller/ -run TestValidateTemplateAlignment || echo "Controller tests skipped"
 	@echo ""
@@ -163,7 +163,7 @@ ci-tests: fmt vet ## Run the same tests as CI pipeline (unit tests only, fast ex
 		./internal/nbi/models/ \
 		./internal/nbi/validation/
 	@go test -v -coverprofile=coverage-storage.out ./internal/nbi/storage/ \
-		-run "TestInMemory|TestCreateResourceYAML|TestParseResourceYAML|TestRoundTrip|TestExtractResourceID|TestGenerateWorkspaceName|TestSetResource|TestConvertTo|TestCreateKptfile|TestPorchStorageTLS"
+		-run "TestInMemory|TestCreateResourceYAML|TestParseResourceYAML|TestRoundTrip|TestExtractResourceID|TestGenerateWorkspaceName|TestSetResource|TestConvertTo|TestCreateKptfile|TestPorchStorageTLS|TestPorchStorageAuth"
 	@go test -v -coverprofile=coverage-controller.out \
 		./internal/controller/ -run TestValidateTemplateAlignment || echo "Controller tests skipped"
 	@echo ""

--- a/operators/focom-operator/cmd/main.go
+++ b/operators/focom-operator/cmd/main.go
@@ -33,6 +33,7 @@ import (
 	"fmt"
 	focomv1alpha1 "github.com/nephio-project/nephio/operators/focom-operator/api/focom/v1alpha1"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -73,6 +74,13 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
+// envBool reports whether the named environment variable holds a true value.
+// Unset, empty and unparseable all read as false.
+func envBool(name string) bool {
+	value, err := strconv.ParseBool(os.Getenv(name))
+	return err == nil && value
+}
+
 // initializeNBISystem initializes the complete NBI system with all components
 func initializeNBISystem(mgr ctrl.Manager, nbiConfig *config.NBIConfig) (*nbi.Server, error) {
 	setupLog.Info("Initializing NBI system", "stage", nbiConfig.Stage, "storageBackend", nbiConfig.StorageBackend)
@@ -96,15 +104,23 @@ func initializeNBISystem(mgr ctrl.Manager, nbiConfig *config.NBIConfig) (*nbi.Se
 			repository = "focom-resources"
 		}
 
-		httpsVerify := os.Getenv("PORCH_HTTPS_VERIFY") == "true"
+		// Certificates are verified unless development explicitly opts out.
+		insecureSkipTLSVerify := envBool("UNSAFE_SKIP_TLS_VERIFY")
+		if insecureSkipTLSVerify {
+			setupLog.Info("UNSAFE_SKIP_TLS_VERIFY is set: the Kubernetes API server certificate will NOT be verified " +
+				"and the service account token can be intercepted. Never enable this outside development.")
+		}
+		if _, ok := os.LookupEnv("PORCH_HTTPS_VERIFY"); ok {
+			setupLog.Info("PORCH_HTTPS_VERIFY is no longer supported and is ignored; certificates are always verified " +
+				"unless UNSAFE_SKIP_TLS_VERIFY=true")
+		}
 
 		porchConfig := &storage.PorchStorageConfig{
-			Namespace:   namespace,
-			Repository:  repository,
-			HTTPSVerify: httpsVerify,
-			// KubernetesURL and Token will be auto-detected from environment
-			// KUBERNETES_BASE_URL env var or default to "https://kubernetes.default.svc"
-			// TOKEN env var or service account token file
+			Namespace:             namespace,
+			Repository:            repository,
+			InsecureSkipTLSVerify: insecureSkipTLSVerify,
+			// KubernetesURL, Token and the API server CA are auto-detected from
+			// the environment: KUBERNETES_BASE_URL, TOKEN, KUBERNETES_CA_FILE
 		}
 
 		var err error

--- a/operators/focom-operator/config/manager/manager.yaml
+++ b/operators/focom-operator/config/manager/manager.yaml
@@ -78,10 +78,6 @@ spec:
           value: "default"
         - name: PORCH_REPOSITORY
           value: "focom-resources"
-        - name: KUBERNETES_BASE_URL
-          value: "https://kubernetes.default.svc"
-        - name: PORCH_HTTPS_VERIFY
-          value: "false"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/operators/focom-operator/docs/ARCHITECTURE.md
+++ b/operators/focom-operator/docs/ARCHITECTURE.md
@@ -719,7 +719,8 @@ Each revision is immutable and stored permanently in Git.
 
 **In-Cluster:**
 - Service account token mounted at `/var/run/secrets/kubernetes.io/serviceaccount/token`
-- Automatic token rotation by Kubernetes
+- The client is given that path rather than its contents, so a token the kubelet
+  rotates is picked up without a restart
 
 **Local Development:**
 - Token from `KUBECONFIG` file

--- a/operators/focom-operator/docs/DEPLOYMENT.md
+++ b/operators/focom-operator/docs/DEPLOYMENT.md
@@ -284,11 +284,16 @@ NBI_STAGE=2                        # Stage 2 (Porch)
 **Optional (with defaults):**
 ```bash
 FOCOM_NAMESPACE=focom-system       # Default namespace for FOCOM resources (default: focom-system)
-KUBERNETES_BASE_URL=https://kubernetes.default.svc  # K8s API URL (auto-detected)
-TOKEN=/var/run/secrets/kubernetes.io/serviceaccount/token  # Auth token (auto-detected)
 PORCH_NAMESPACE=default            # Namespace for PackageRevisions (default: default)
 PORCH_REPOSITORY=focom-resources   # Porch repository name (default: focom-resources)
 ```
+
+In a pod, leave the API server address, token and CA unset: they are taken from
+the service account volume and the address Kubernetes advertises. Setting
+`KUBERNETES_BASE_URL` turns an auto-detected value into a fixed one, and the
+address it must then match is the only one the API server certificate is
+guaranteed to cover. `KUBERNETES_BASE_URL` must be an `https://` URL; a
+plaintext endpoint is refused, because the token is sent with every request.
 
 **Note:** The `FOCOM_NAMESPACE` environment variable sets the default namespace for all FOCOM resources (OCloud, TemplateInfo, FocomProvisioningRequest). This eliminates the need to specify namespace in API request bodies.
 
@@ -1079,8 +1084,8 @@ kubectl scale deployment focom-operator-controller-manager --replicas=3 -n focom
 ### Security
 
 ```bash
-# Enable TLS verification
-# Set in PorchStorageConfig: HTTPSVerify: true
+# TLS verification of the Kubernetes API server is on by default.
+# Never set UNSAFE_SKIP_TLS_VERIFY=true outside development.
 
 # Use network policies
 kubectl apply -f config/network-policies/

--- a/operators/focom-operator/docs/PORCH_SETUP.md
+++ b/operators/focom-operator/docs/PORCH_SETUP.md
@@ -411,6 +411,19 @@ spec:
         #   value: "focom-resources"
 ```
 
+**TLS:** the Kubernetes API server certificate is verified against the CA bundle
+mounted at `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`, so no TLS
+configuration is needed for an in-cluster deployment.
+
+**Proxies:** the client now honours `HTTPS_PROXY` and `NO_PROXY`, like every
+other Kubernetes client. If your cluster exports `HTTPS_PROXY` to workloads,
+make sure `NO_PROXY` covers the API server address; otherwise this connection
+starts going through the proxy. A proxy that terminates TLS will fail the
+handshake, because the cluster CA does not sign its certificate. Leave `KUBERNETES_BASE_URL`
+unset unless you must reach a different endpoint: the operator then uses the
+address from `$KUBERNETES_SERVICE_HOST`, which is the one Kubernetes expects the
+API server certificate to be valid for.
+
 Apply the changes:
 
 ```bash
@@ -459,9 +472,20 @@ export TOKEN=/tmp/kube-token
 # Optional: Override repository name (default: "focom-resources")
 # export PORCH_REPOSITORY=focom-resources
 
+# Optional: CA bundle used to verify the API server certificate. Needed only
+# when running outside the cluster with KUBERNETES_BASE_URL, since a kubeconfig
+# already carries its cluster CA.
+# export KUBERNETES_CA_FILE=/path/to/ca.crt
+
 # Run the operator
 go run ./cmd/main.go
 ```
+
+**TLS:** the API server certificate is always verified. If your development
+cluster presents a certificate you cannot verify, export the cluster CA through
+`KUBERNETES_CA_FILE`. As a last resort `UNSAFE_SKIP_TLS_VERIFY=true` disables
+verification entirely — it sends your bearer token to an unauthenticated
+endpoint and must never be used outside development.
 
 ### Step 6: Verify Operator Startup
 
@@ -811,11 +835,13 @@ git log --oneline
 | `NBI_STORAGE_BACKEND` | Yes | `memory` | Storage backend type (`memory` or `porch`) |
 | `NBI_STAGE` | Yes | `1` | Implementation stage (`1`, `2`, or `3`) |
 | `FOCOM_NAMESPACE` | No | `focom-system` | Default namespace for FOCOM resources (OCloud, TemplateInfo, FocomProvisioningRequest) |
-| `KUBERNETES_BASE_URL` | No | `https://kubernetes.default.svc` | Kubernetes API server URL |
+| `KUBERNETES_BASE_URL` | No | In-cluster API server address | Kubernetes API server URL |
 | `TOKEN` | No | Auto-detected | Authentication token (string or file path) |
 | `KUBECONFIG` | No | `~/.kube/config` | Path to kubeconfig file (local development) |
 | `PORCH_NAMESPACE` | No | `default` | Namespace for PackageRevisions |
 | `PORCH_REPOSITORY` | No | `focom-resources` | Porch repository name |
+| `KUBERNETES_CA_FILE` | No | In-cluster CA | PEM bundle used to verify the API server certificate |
+| `UNSAFE_SKIP_TLS_VERIFY` | No | `false` | Development only: skip verification of the API server certificate |
 
 ### PorchStorageConfig Fields
 
@@ -825,16 +851,17 @@ git log --oneline
 | `Token` | string | No | Auto-detected | Authentication token |
 | `Namespace` | string | Yes | - | Namespace for PackageRevisions |
 | `Repository` | string | Yes | - | Porch repository name |
-| `HTTPSVerify` | bool | No | `false` | Verify HTTPS certificates |
+| `CAFile` | string | No | In-cluster CA | PEM bundle used to verify the API server certificate |
+| `InsecureSkipTLSVerify` | bool | No | `false` | Development only: skip verification of the API server certificate |
 
 ## Best Practices
 
 ### Production Deployments
 
-1. **Use HTTPS with Certificate Verification:**
-   ```go
-   HTTPSVerify: true
-   ```
+1. **Keep Certificate Verification Enabled:**
+   The API server certificate is verified by default. Never set
+   `UNSAFE_SKIP_TLS_VERIFY` in production: it sends the service account token
+   to an endpoint whose identity has not been checked.
 
 2. **Use Private Git Repositories:**
    - Store sensitive configuration in private repositories
@@ -863,10 +890,12 @@ git log --oneline
    - Gitea or GitLab in Docker
    - Faster access, no external dependencies
 
-3. **Disable HTTPS Verification:**
-   ```go
-   HTTPSVerify: false
+3. **Point at the Cluster CA:**
+   ```bash
+   export KUBERNETES_CA_FILE=/path/to/cluster-ca.crt
    ```
+   Certificates stay verified. `UNSAFE_SKIP_TLS_VERIFY=true` turns verification
+   off if you have no CA to hand, and logs a warning at startup.
 
 4. **Use Automatic Token Resolution:**
    - Let the operator extract token from kubeconfig

--- a/operators/focom-operator/internal/nbi/integration_test.go
+++ b/operators/focom-operator/internal/nbi/integration_test.go
@@ -87,7 +87,8 @@ func NewTestServerWithConfig(config *TestConfig) *TestServer {
 			Token:                  config.Porch.Token,
 			Namespace:              config.Porch.Namespace,
 			Repository:             config.Porch.Repository,
-			HTTPSVerify:            config.Porch.HTTPSVerify,
+			CAFile:                 config.Porch.CAFile,
+			InsecureSkipTLSVerify:  config.Porch.InsecureSkipTLSVerify,
 			PackageRevisionTimeout: 120 * time.Second, // Use 2 minutes for tests (default is 30s)
 		}
 		storageImpl, err = storage.NewPorchStorage(porchConfig)

--- a/operators/focom-operator/internal/nbi/storage/porch.go
+++ b/operators/focom-operator/internal/nbi/storage/porch.go
@@ -58,6 +58,8 @@ const (
 	// defaultInClusterCAFile is where Kubernetes publishes the API server CA
 	// in a pod.
 	defaultInClusterCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	// #nosec G101 -- standard service account token path, not a credential
+	defaultInClusterTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 	// defaultRequestTimeout bounds every call to the Kubernetes API.
 	defaultRequestTimeout = 30 * time.Second
 )
@@ -67,13 +69,15 @@ const (
 // in any pod with the service account credential attached, including the one a
 // test runs in, so a test asserting that the bundle is absent would otherwise
 // pass on a laptop and fail in CI.
-var inClusterCAFile = defaultInClusterCAFile
+var (
+	inClusterCAFile    = defaultInClusterCAFile
+	inClusterTokenFile = defaultInClusterTokenFile
+)
 
 // PorchStorage implements StorageInterface using Nephio Porch via REST API
 type PorchStorage struct {
 	httpClient             *http.Client
 	kubernetesURL          string        // e.g., "https://kubernetes.default.svc"
-	token                  string        // Service account token
 	namespace              string        // Namespace for PackageRevisions (usually "default")
 	repository             string        // Porch repository name (e.g., "focom-resources")
 	packageRevisionTimeout time.Duration // Timeout for waiting for PackageRevision operations (default: 30s)
@@ -87,7 +91,7 @@ type PorchStorageConfig struct {
 	Repository             string        // Porch repository name (e.g., "focom-resources")
 	CAFile                 string        // CA bundle verifying the API server (optional, defaults to KUBERNETES_CA_FILE env or the in-cluster CA)
 	InsecureSkipTLSVerify  bool          // Development only: skip API server certificate verification, exposing the token (default: false)
-	UseKubeconfig          bool          // Use kubeconfig for authentication (client certs; exec plugins are not yet honoured, see #1171)
+	UseKubeconfig          bool          // Use kubeconfig for authentication (client certs, tokens and exec plugins)
 	Kubeconfig             string        // Path to kubeconfig file (optional, defaults to KUBECONFIG env or ~/.kube/config)
 	PackageRevisionTimeout time.Duration // Timeout for waiting for PackageRevision operations (optional, default: 30s)
 }
@@ -144,7 +148,7 @@ func newPorchStorageFromKubeconfig(config *PorchStorageConfig) (*PorchStorage, e
 		return nil, err
 	}
 
-	httpClient, err := rest.HTTPClientFor(restConfig)
+	httpClient, err := newHTTPClient(restConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP client from kubeconfig: %w", err)
 	}
@@ -158,7 +162,6 @@ func newPorchStorageFromKubeconfig(config *PorchStorageConfig) (*PorchStorage, e
 	return &PorchStorage{
 		httpClient:             httpClient,
 		kubernetesURL:          restConfig.Host,
-		token:                  restConfig.BearerToken, // May be empty if using exec/cert auth
 		namespace:              config.Namespace,
 		repository:             config.Repository,
 		packageRevisionTimeout: prTimeout,
@@ -167,27 +170,22 @@ func newPorchStorageFromKubeconfig(config *PorchStorageConfig) (*PorchStorage, e
 
 // newPorchStorageWithToken creates PorchStorage using token-based authentication (original method)
 func newPorchStorageWithToken(config *PorchStorageConfig) (*PorchStorage, error) {
-	// 1. Get service account token (env var, file, or kubeconfig)
-	token := config.Token
-	if token == "" {
-		var err error
-		token, err = resolveToken()
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve authentication token: %w", err)
-		}
-	}
-
-	// 2. Get the address and TLS settings (verifies the API server by default)
+	// 1. Get the address and TLS settings (verifies the API server by default)
 	restConfig, err := buildRESTConfig(config)
 	if err != nil {
 		return nil, err
+	}
+
+	// 2. Point it at the token, so that the transport signs each request
+	if err := resolveCredentials(config, restConfig); err != nil {
+		return nil, fmt.Errorf("failed to resolve authentication token: %w", err)
 	}
 
 	if err := pinConfiguredCA(restConfig); err != nil {
 		return nil, err
 	}
 
-	httpClient, err := rest.HTTPClientFor(restConfig)
+	httpClient, err := newHTTPClient(restConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
 	}
@@ -201,7 +199,6 @@ func newPorchStorageWithToken(config *PorchStorageConfig) (*PorchStorage, error)
 	return &PorchStorage{
 		httpClient:             httpClient,
 		kubernetesURL:          restConfig.Host,
-		token:                  token,
 		namespace:              config.Namespace,
 		repository:             config.Repository,
 		packageRevisionTimeout: prTimeout,
@@ -416,41 +413,54 @@ func buildRESTConfig(config *PorchStorageConfig) (*rest.Config, error) {
 	return restConfig, nil
 }
 
-// resolveToken attempts to resolve the authentication token from multiple sources
-func resolveToken() (string, error) {
-	// Try TOKEN environment variable (can be token string or file path)
-	tokenEnv := os.Getenv("TOKEN")
-	if tokenEnv != "" {
-		// Check if it's a file path or token string
-		cleanTokenPath := filepath.Clean(tokenEnv)
-		if _, err := os.Stat(cleanTokenPath); err == nil {
-			// It's a file path, read it
-			tokenBytes, err := os.ReadFile(cleanTokenPath) // #nosec G304 -- token path from trusted env var
-			if err != nil {
-				return "", fmt.Errorf("failed to read token from file %s: %w", tokenEnv, err)
-			}
-			return strings.TrimSpace(string(tokenBytes)), nil
+// resolveCredentials points restConfig at the operator's token.
+//
+// The path is preferred over its contents wherever there is one. client-go
+// re-reads a BearerTokenFile as it goes, which is what a projected service
+// account token needs: the kubelet replaces it long before it expires, and a
+// value read once at startup stops being accepted while the process keeps
+// running.
+func resolveCredentials(config *PorchStorageConfig, restConfig *rest.Config) error {
+	if config.Token != "" {
+		restConfig.BearerToken = config.Token
+		return nil
+	}
+
+	// TOKEN carries either a path or the token itself.
+	//
+	// An absolute one is a path and nothing else, so a missing file there is a
+	// mistake rather than a credential: an unmounted volume or a typo used to
+	// be sent to the API server as the token, which reads back as an opaque
+	// 401 and writes the filesystem layout into someone's request log. Only
+	// the leading separator is tested, and not any separator, because a token
+	// in standard base64 can contain one and used to work.
+	if tokenEnv := os.Getenv("TOKEN"); tokenEnv != "" {
+		cleaned := filepath.Clean(tokenEnv)
+		_, err := os.Stat(cleaned)
+		switch {
+		case err == nil:
+			restConfig.BearerTokenFile = cleaned
+		case filepath.IsAbs(tokenEnv):
+			return fmt.Errorf("TOKEN names a file that cannot be used: %w", err)
+		default:
+			restConfig.BearerToken = tokenEnv
 		}
-		// It's a token string
-		return tokenEnv, nil
+		return nil
 	}
 
-	// Try default in-cluster token path
-	tokenPath := "/var/run/secrets/kubernetes.io/serviceaccount/token" // #nosec G101 -- standard k8s service account token path
-	if tokenBytes, err := os.ReadFile(tokenPath); err == nil {
-		return strings.TrimSpace(string(tokenBytes)), nil
+	if _, err := os.Stat(inClusterTokenFile); err == nil {
+		restConfig.BearerTokenFile = inClusterTokenFile
+		return nil
 	}
 
-	// Try to read from kubeconfig as fallback
 	token, err := readTokenFromKubeconfig()
 	if err != nil {
-		return "", fmt.Errorf("failed to read token from environment, file, or kubeconfig: %w", err)
+		return fmt.Errorf("failed to read token from environment, file, or kubeconfig: %w", err)
 	}
-
-	return token, nil
+	restConfig.BearerToken = token
+	return nil
 }
 
-// readTokenFromKubeconfig reads token from kubeconfig file
 func readTokenFromKubeconfig() (string, error) {
 	kubeconfigPath := os.Getenv("KUBECONFIG")
 	if kubeconfigPath == "" {
@@ -524,6 +534,36 @@ func (s *PorchStorage) HealthCheck(ctx context.Context) error {
 	return nil
 }
 
+// newHTTPClient builds the client for a rest.Config and refuses to follow
+// redirects.
+//
+// Porch is an aggregated API server, and CVE-2022-3172 is that exact shape: an
+// aggregated API server answers 3XX and the client follows it with its
+// credentials attached. Kubernetes fixed it by blocking 3XX from aggregated
+// API servers by default, and the same has to hold on this side, because the
+// token is attached by a RoundTripper now. net/http drops an Authorization
+// header the caller set when a redirect crosses hosts, but it cannot drop one
+// the transport adds on the next hop:
+//
+//	header set by the caller,  redirected to another host -> ""
+//	header added by transport, redirected to another host -> "Bearer <token>"
+func newHTTPClient(restConfig *rest.Config) (*http.Client, error) {
+	httpClient, err := rest.HTTPClientFor(restConfig)
+	if err != nil {
+		return nil, err
+	}
+	if httpClient == http.DefaultClient {
+		// Only returned for a config with no TLS, no credentials and no
+		// timeout, none of which this operator builds. Setting CheckRedirect
+		// on it would reach every other user of the process.
+		return nil, errors.New("refusing to configure the shared HTTP client")
+	}
+	httpClient.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
+		return fmt.Errorf("refusing to follow a redirect to %s", req.URL.Redacted())
+	}
+	return httpClient, nil
+}
+
 // makeRequest creates and executes an HTTP request to Kubernetes API
 func (s *PorchStorage) makeRequest(ctx context.Context, method, path string, body interface{}) (*http.Response, error) {
 	var reqBody []byte
@@ -553,7 +593,9 @@ func (s *PorchStorage) makeRequest(ctx context.Context, method, path string, bod
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", s.token))
+	// Authorization is left to the transport. Both of client-go's credential
+	// wrappers return early when the header is already set, so writing it here
+	// is what suppressed them.
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {

--- a/operators/focom-operator/internal/nbi/storage/porch.go
+++ b/operators/focom-operator/internal/nbi/storage/porch.go
@@ -19,14 +19,19 @@ package storage
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -46,6 +51,24 @@ const (
 	PorchLifecyclePublished = "Published"
 )
 
+// Kubernetes API connection defaults
+const (
+	// defaultKubernetesURL is used only outside a cluster; see buildRESTConfig.
+	defaultKubernetesURL = "https://kubernetes.default.svc"
+	// defaultInClusterCAFile is where Kubernetes publishes the API server CA
+	// in a pod.
+	defaultInClusterCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	// defaultRequestTimeout bounds every call to the Kubernetes API.
+	defaultRequestTimeout = 30 * time.Second
+)
+
+// inClusterCAFile is a variable so that tests can point it somewhere that
+// definitely does not exist. Kubernetes mounts a CA bundle at the default path
+// in any pod with the service account credential attached, including the one a
+// test runs in, so a test asserting that the bundle is absent would otherwise
+// pass on a laptop and fail in CI.
+var inClusterCAFile = defaultInClusterCAFile
+
 // PorchStorage implements StorageInterface using Nephio Porch via REST API
 type PorchStorage struct {
 	httpClient             *http.Client
@@ -62,8 +85,9 @@ type PorchStorageConfig struct {
 	Token                  string        // Service account token (optional, will auto-detect)
 	Namespace              string        // Namespace for PackageRevisions (usually "default")
 	Repository             string        // Porch repository name (e.g., "focom-resources")
-	HTTPSVerify            bool          // Whether to verify HTTPS certificates (default: false for dev)
-	UseKubeconfig          bool          // Use kubeconfig for authentication (handles exec, certs, etc.)
+	CAFile                 string        // CA bundle verifying the API server (optional, defaults to KUBERNETES_CA_FILE env or the in-cluster CA)
+	InsecureSkipTLSVerify  bool          // Development only: skip API server certificate verification, exposing the token (default: false)
+	UseKubeconfig          bool          // Use kubeconfig for authentication (client certs; exec plugins are not yet honoured, see #1171)
 	Kubeconfig             string        // Path to kubeconfig file (optional, defaults to KUBECONFIG env or ~/.kube/config)
 	PackageRevisionTimeout time.Duration // Timeout for waiting for PackageRevision operations (optional, default: 30s)
 }
@@ -108,19 +132,27 @@ func newPorchStorageFromKubeconfig(config *PorchStorageConfig) (*PorchStorage, e
 		return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
 	}
 
+	if err := validateAPIServerURL(restConfig.Host); err != nil {
+		return nil, err
+	}
+
+	// Set on the config: HTTPClientFor may return the shared http.DefaultClient.
+	restConfig.Timeout = defaultRequestTimeout
+
 	// Create HTTP client with kubeconfig's transport (handles auth automatically)
+	if err := pinConfiguredCA(restConfig); err != nil {
+		return nil, err
+	}
+
 	httpClient, err := rest.HTTPClientFor(restConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP client from kubeconfig: %w", err)
 	}
 
-	// Set timeout
-	httpClient.Timeout = 30 * time.Second
-
 	// Set default PackageRevision timeout if not specified
 	prTimeout := config.PackageRevisionTimeout
 	if prTimeout == 0 {
-		prTimeout = 30 * time.Second
+		prTimeout = defaultRequestTimeout
 	}
 
 	return &PorchStorage{
@@ -135,16 +167,7 @@ func newPorchStorageFromKubeconfig(config *PorchStorageConfig) (*PorchStorage, e
 
 // newPorchStorageWithToken creates PorchStorage using token-based authentication (original method)
 func newPorchStorageWithToken(config *PorchStorageConfig) (*PorchStorage, error) {
-	// 1. Get Kubernetes API URL (env var or default)
-	kubernetesURL := config.KubernetesURL
-	if kubernetesURL == "" {
-		kubernetesURL = os.Getenv("KUBERNETES_BASE_URL")
-		if kubernetesURL == "" {
-			kubernetesURL = "https://kubernetes.default.svc"
-		}
-	}
-
-	// 2. Get service account token (env var, file, or kubeconfig)
+	// 1. Get service account token (env var, file, or kubeconfig)
 	token := config.Token
 	if token == "" {
 		var err error
@@ -154,30 +177,243 @@ func newPorchStorageWithToken(config *PorchStorageConfig) (*PorchStorage, error)
 		}
 	}
 
-	// 3. Create HTTP client with timeout and TLS config
-	httpClient := &http.Client{
-		Timeout: 30 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: !config.HTTPSVerify, // #nosec G402 -- configurable TLS verification for dev environments
-			},
-		},
+	// 2. Get the address and TLS settings (verifies the API server by default)
+	restConfig, err := buildRESTConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := pinConfiguredCA(restConfig); err != nil {
+		return nil, err
+	}
+
+	httpClient, err := rest.HTTPClientFor(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
 	}
 
 	// Set default PackageRevision timeout if not specified
 	prTimeout := config.PackageRevisionTimeout
 	if prTimeout == 0 {
-		prTimeout = 30 * time.Second
+		prTimeout = defaultRequestTimeout
 	}
 
 	return &PorchStorage{
 		httpClient:             httpClient,
-		kubernetesURL:          kubernetesURL,
+		kubernetesURL:          restConfig.Host,
 		token:                  token,
 		namespace:              config.Namespace,
 		repository:             config.Repository,
 		packageRevisionTimeout: prTimeout,
 	}, nil
+}
+
+// explicitKubernetesURL returns the configured API server URL, or "" if unset.
+func explicitKubernetesURL(config *PorchStorageConfig) string {
+	if config.KubernetesURL != "" {
+		return config.KubernetesURL
+	}
+	return os.Getenv("KUBERNETES_BASE_URL")
+}
+
+// validateAPIServerURL rejects endpoints that cannot carry a bearer token
+// safely. Plaintext is refused outright: skipping certificate verification is
+// an explicit opt-in, sending the token in the clear is never one.
+func validateAPIServerURL(host string) error {
+	parsed, err := url.Parse(host)
+	if err != nil {
+		return fmt.Errorf("invalid Kubernetes API URL %q: %w", host, err)
+	}
+	switch {
+	case parsed.Scheme != "https":
+		return fmt.Errorf("the Kubernetes API URL %q must use https, the service account token is sent with every request", host)
+	case parsed.Host == "":
+		return fmt.Errorf("the Kubernetes API URL %q has no host", host)
+	case !isUnambiguousHost(parsed.Hostname()):
+		return fmt.Errorf("the Kubernetes API URL %q has an unusable host %q", host, parsed.Hostname())
+	case parsed.User != nil:
+		return fmt.Errorf("the Kubernetes API URL %q must not embed credentials", host)
+	case parsed.RawQuery != "" || parsed.ForceQuery || strings.Contains(host, "#"):
+		// A bare "?" survives as ForceQuery and a bare "#" as an empty
+		// Fragment, and both then swallow the API path this is joined to.
+		return fmt.Errorf("the Kubernetes API URL %q must not carry a query or fragment", host)
+	}
+	if _, err := effectiveAPIServerPort(parsed); err != nil {
+		return fmt.Errorf("the Kubernetes API URL %q has an %w", host, err)
+	}
+	return nil
+}
+
+// hostLabel matches one letter-digit-hyphen label, which is all a hostname may
+// be. Anything a second parser could read differently is outside it.
+var hostLabel = regexp.MustCompile(`^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?$`)
+
+// isUnambiguousHost reports whether every parser reads host as the same host.
+// net/http keeps a name like "ⓔxample.com" as written while the transport maps
+// it to "example.com" before dialling, so the address checked would not be the
+// one used. Allowing a shape is steadier than refusing characters by name.
+func isUnambiguousHost(host string) bool {
+	if net.ParseIP(host) != nil {
+		return true
+	}
+	if host == "" || len(host) > 253 {
+		return false
+	}
+	for _, label := range strings.Split(strings.TrimSuffix(host, "."), ".") {
+		if !hostLabel.MatchString(label) {
+			return false
+		}
+	}
+	return true
+}
+
+// pinConfiguredCA replaces a named bundle with the bytes that were checked.
+//
+// client-go loads a CA file by appending it to an empty pool and keeping the
+// pool only if something was added, so a file of zero bytes leaves RootCAs nil
+// and the connection falls back to whatever the container image trusts. That
+// is not what naming a bundle asks for: it is a wider trust boundary than the
+// cluster CA, arrived at silently. A file that cannot be parsed is refused
+// already; an empty one has to be refused too.
+//
+// The bytes that were parsed are the bytes installed, and the path is cleared,
+// so the transport cannot read a different file than the one checked.
+func pinConfiguredCA(restConfig *rest.Config) error {
+	if restConfig.Insecure || (len(restConfig.CAData) == 0 && restConfig.CAFile == "") {
+		return nil
+	}
+
+	data, source := restConfig.CAData, "the configured certificate-authority-data"
+	if len(data) == 0 {
+		source = restConfig.CAFile
+		var err error
+		// The call is its own statement: gosec attaches #nosec to a statement,
+		// and inside an if initialiser the annotation lands on the if rather
+		// than on the read, so v2.22.0 reports G304 anyway.
+		data, err = os.ReadFile(source) // #nosec G304 G703 -- operator configuration
+		if err != nil {
+			return fmt.Errorf("cannot read the Kubernetes API CA %q: %w", source, err)
+		}
+	}
+
+	if !x509.NewCertPool().AppendCertsFromPEM(data) {
+		return fmt.Errorf("the Kubernetes API CA %q holds no certificate", source)
+	}
+
+	restConfig.CAData = data
+	restConfig.CAFile = ""
+	return nil
+}
+
+// effectiveAPIServerPort returns the port as a number, or an error if it is
+// not one an endpoint can have. url.Parse only checks the port is digits, so
+// ":0443" and ":443" both parse and compare unequal as strings while naming
+// the same endpoint, and ":65536" parses while nothing can listen on it.
+func effectiveAPIServerPort(parsed *url.URL) (string, error) {
+	port := parsed.Port()
+	if port == "" {
+		return "443", nil
+	}
+	number, err := strconv.ParseUint(port, 10, 16)
+	if err != nil || number == 0 {
+		return "", fmt.Errorf("invalid port %q", port)
+	}
+	return strconv.FormatUint(number, 10), nil
+}
+
+// apiServerOrigin reduces a URL to the endpoint its certificate is issued for.
+// https://host and https://host:443 name one endpoint, as do the short and long
+// spellings of an IPv6 address, so comparing URLs as written would send
+// equivalent addresses down different trust paths.
+func apiServerOrigin(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if ip := net.ParseIP(host); ip != nil {
+		host = ip.String()
+	}
+	port, err := effectiveAPIServerPort(parsed)
+	if err != nil {
+		return rawURL
+	}
+	return strings.ToLower(parsed.Scheme) + "://" + net.JoinHostPort(host, port)
+}
+
+// buildRESTConfig returns the address and TLS settings for the Kubernetes API.
+// In a pod the cluster CA has to load: InClusterConfig only logs a bundle it
+// cannot read, so the alternative is not a failed handshake but silent
+// promotion to whatever the container image happens to trust.
+// The client this builds honours HTTPS_PROXY and NO_PROXY, because client-go
+// installs http.ProxyFromEnvironment. The transport this replaces set no proxy
+// at all, so on a cluster that exports HTTPS_PROXY without a NO_PROXY entry for
+// the API server, this connection starts going through it. That matches the
+// manager's own client in the same binary, which has always used client-go, and
+// a proxy that terminates TLS now fails the handshake against the pinned
+// cluster CA rather than quietly reading the token.
+func buildRESTConfig(config *PorchStorageConfig) (*rest.Config, error) {
+	restConfig := &rest.Config{Timeout: defaultRequestTimeout}
+
+	// Read from the environment rather than through rest.InClusterConfig,
+	// which reads the fixed service account token before it will hand back the
+	// host and CA. A pod that turns off the default mount and projects its
+	// token elsewhere supplies everything needed here and would still be
+	// refused. Kubernetes only promises a certificate valid for the address it
+	// advertises, so that is the one to use.
+	host, port := os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")
+	inClusterHost := ""
+	if host != "" || port != "" {
+		if host == "" || port == "" {
+			return nil, errors.New("KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be set together")
+		}
+		inClusterHost = "https://" + net.JoinHostPort(host, port)
+	}
+
+	restConfig.Host = inClusterHost
+	if kubernetesURL := explicitKubernetesURL(config); kubernetesURL != "" {
+		restConfig.Host = kubernetesURL
+	}
+	if restConfig.Host == "" {
+		restConfig.Host = defaultKubernetesURL
+	}
+	// Before the bundle is chosen rather than after the config is returned:
+	// which CA an address gets is a decision about an endpoint, and an
+	// endpoint that cannot carry a token is not one.
+	if err := validateAPIServerURL(restConfig.Host); err != nil {
+		return nil, err
+	}
+
+	caFile := config.CAFile
+	if caFile == "" {
+		caFile = os.Getenv("KUBERNETES_CA_FILE")
+	}
+	if config.InsecureSkipTLSVerify && caFile != "" {
+		return nil, errors.New("a CA bundle and InsecureSkipTLSVerify are mutually exclusive")
+	}
+	// The cluster bundle is issued for the cluster's own API server, reachable
+	// both at the advertised address and at the in-cluster name. Any other
+	// endpoint is a different server and keeps the system roots. Required
+	// rather than best effort: falling back would widen the trust boundary
+	// instead of failing.
+	origin := apiServerOrigin(restConfig.Host)
+	if caFile == "" && inClusterHost != "" &&
+		(origin == apiServerOrigin(inClusterHost) ||
+			origin == apiServerOrigin(defaultKubernetesURL)) {
+		caFile = inClusterCAFile
+	}
+
+	if config.InsecureSkipTLSVerify {
+		// Drop the bundle rather than the whole TLS config: client-go rejects
+		// the two together, but ServerName and client certs must survive.
+		restConfig.Insecure = true
+		restConfig.CAFile = ""
+		restConfig.CAData = nil
+	} else {
+		restConfig.CAFile = caFile
+	}
+
+	return restConfig, nil
 }
 
 // resolveToken attempts to resolve the authentication token from multiple sources
@@ -300,7 +536,9 @@ func (s *PorchStorage) makeRequest(ctx context.Context, method, path string, bod
 		}
 	}
 
-	url := fmt.Sprintf("%s%s", s.kubernetesURL, path)
+	// Trimmed on both sides: a base URL that ends in "/" produced "//apis",
+	// which the API server answers with a redirect this client refuses.
+	url := strings.TrimRight(s.kubernetesURL, "/") + "/" + strings.TrimLeft(path, "/")
 	var req *http.Request
 
 	if len(reqBody) > 0 {

--- a/operators/focom-operator/internal/nbi/storage/porch_test.go
+++ b/operators/focom-operator/internal/nbi/storage/porch_test.go
@@ -19,7 +19,9 @@ package storage
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"net/http"
@@ -63,7 +65,6 @@ func TestNewPorchStorage_WithConfig(t *testing.T) {
 		Token:         "test-token-12345",
 		Namespace:     "test-namespace",
 		Repository:    "test-repo",
-		HTTPSVerify:   false,
 	}
 
 	storage, err := NewPorchStorage(config)
@@ -124,6 +125,8 @@ func TestNewPorchStorage_WithTokenFile(t *testing.T) {
 func TestNewPorchStorage_DefaultKubernetesURL(t *testing.T) {
 	// Ensure no env var is set
 	os.Unsetenv("KUBERNETES_BASE_URL")
+	// The default only applies outside a cluster.
+	isolateClusterEnv(t)
 
 	config := &PorchStorageConfig{
 		Token:      "test-token",
@@ -162,6 +165,596 @@ func TestNewPorchStorage_MissingRepository(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, storage)
 	assert.Contains(t, err.Error(), "repository is required")
+}
+
+// TLS verification regression tests. Unlike the TEMPORARY set above, these pin
+// a security default and should outlive the seed implementation.
+
+// isolateClusterEnv hides ambient cluster config so the tests see the defaults.
+// TestMain clears the variables the kubelet injects, so that a run inside a
+// pod tests the same thing a run on a laptop does. Without this the suite
+// picks up whichever cluster it happens to be running in, and tests about
+// token resolution start failing on a missing CA bundle. Individual tests
+// still set these with t.Setenv when the environment is what they are about.
+func TestMain(m *testing.M) {
+	for _, key := range []string{
+		"KUBERNETES_SERVICE_HOST",
+		"KUBERNETES_SERVICE_PORT",
+		"KUBERNETES_BASE_URL",
+		"KUBERNETES_CA_FILE",
+		"UNSAFE_SKIP_TLS_VERIFY",
+		"PORCH_HTTPS_VERIFY",
+	} {
+		if err := os.Unsetenv(key); err != nil {
+			panic(err)
+		}
+	}
+	os.Exit(m.Run())
+}
+
+func isolateClusterEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+	t.Setenv("KUBERNETES_BASE_URL", "")
+	t.Setenv("KUBERNETES_CA_FILE", "")
+
+	// The default path is a real file in any pod that mounts the service
+	// account credential, so a test that assumes its absence would behave one
+	// way on a laptop and the other way in CI. Point it somewhere empty.
+	original := inClusterCAFile
+	inClusterCAFile = filepath.Join(t.TempDir(), "absent-ca.crt")
+	t.Cleanup(func() { inClusterCAFile = original })
+}
+
+// withInClusterCA points the fixed in-cluster CA path at the given file for the
+// duration of one test.
+func withInClusterCA(t *testing.T, path string) {
+	t.Helper()
+	original := inClusterCAFile
+	inClusterCAFile = path
+	t.Cleanup(func() { inClusterCAFile = original })
+}
+
+// newPorchTLSServer starts an HTTPS stand-in for the Kubernetes API. Its
+// certificate is signed by an authority no trust store knows, like a cluster CA.
+func newPorchTLSServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"apiVersion": "porch.kpt.dev/v1alpha1",
+			"kind":       "PackageRevisionList",
+			"items":      []interface{}{},
+		})
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// writeCAFile writes cert to a PEM bundle usable as a trusted CA.
+func writeCAFile(t *testing.T, cert *x509.Certificate) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ca.crt")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+	require.NoError(t, os.WriteFile(path, pemBytes, 0600))
+	return path
+}
+
+// TestPorchStorageTLS_VerifiedByDefault checks that the token is not sent to
+// an API server whose certificate cannot be verified.
+func TestPorchStorageTLS_VerifiedByDefault(t *testing.T) {
+	isolateClusterEnv(t)
+	server := newPorchTLSServer(t)
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL: server.URL,
+		Token:         "test-token",
+		Namespace:     "default",
+		Repository:    "focom-resources",
+	})
+	require.NoError(t, err)
+
+	err = storage.HealthCheck(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "x509: certificate signed by unknown authority")
+}
+
+// TestPorchStorageTLS_TrustsConfiguredCA checks that CAFile is used.
+func TestPorchStorageTLS_TrustsConfiguredCA(t *testing.T) {
+	isolateClusterEnv(t)
+	server := newPorchTLSServer(t)
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL: server.URL,
+		Token:         "test-token",
+		Namespace:     "default",
+		Repository:    "focom-resources",
+		CAFile:        writeCAFile(t, server.Certificate()),
+	})
+	require.NoError(t, err)
+
+	assert.NoError(t, storage.HealthCheck(context.Background()))
+}
+
+// TestPorchStorageTLS_CAFileFromEnv checks that KUBERNETES_CA_FILE is used.
+func TestPorchStorageTLS_CAFileFromEnv(t *testing.T) {
+	isolateClusterEnv(t)
+	server := newPorchTLSServer(t)
+	t.Setenv("KUBERNETES_CA_FILE", writeCAFile(t, server.Certificate()))
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL: server.URL,
+		Token:         "test-token",
+		Namespace:     "default",
+		Repository:    "focom-resources",
+	})
+	require.NoError(t, err)
+
+	assert.NoError(t, storage.HealthCheck(context.Background()))
+}
+
+// TestPorchStorageTLS_UnreadableCAFile checks that a broken bundle fails early.
+func TestPorchStorageTLS_UnreadableCAFile(t *testing.T) {
+	isolateClusterEnv(t)
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL: "https://test-k8s-api:6443",
+		Token:         "test-token",
+		Namespace:     "default",
+		Repository:    "focom-resources",
+		CAFile:        filepath.Join(t.TempDir(), "missing.crt"),
+	})
+	assert.Error(t, err)
+	assert.Nil(t, storage)
+}
+
+// TestPorchStorageTLS_RejectsPlainHTTP checks that a plaintext endpoint is
+// refused outright, so the bearer token never reaches it.
+func TestPorchStorageTLS_RejectsPlainHTTP(t *testing.T) {
+	isolateClusterEnv(t)
+	var reached int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached++
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	for _, insecure := range []bool{false, true} {
+		storage, err := NewPorchStorage(&PorchStorageConfig{
+			KubernetesURL:         server.URL,
+			Token:                 "test-token",
+			Namespace:             "default",
+			Repository:            "focom-resources",
+			InsecureSkipTLSVerify: insecure,
+		})
+		require.Error(t, err, "insecure=%v", insecure)
+		assert.Nil(t, storage)
+		assert.Contains(t, err.Error(), "must use https")
+	}
+	assert.Zero(t, reached, "the plaintext server must never be contacted")
+}
+
+// TestPorchStorageTLS_RejectsUnusableURL checks the remaining endpoint shapes
+// that cannot carry a credential safely.
+func TestPorchStorageTLS_RejectsUnusableURL(t *testing.T) {
+	isolateClusterEnv(t)
+	for name, kubernetesURL := range map[string]string{
+		"hostless":    "https://",
+		"relative":    "kubernetes.default.svc",
+		"malformed":   "https://%zz",
+		"credentials": "https://user:pass@api.example.com:6443",
+		"query":       "https://api.example.com:6443?token=x",
+	} {
+		t.Run(name, func(t *testing.T) {
+			storage, err := NewPorchStorage(&PorchStorageConfig{
+				KubernetesURL: kubernetesURL,
+				Token:         "test-token",
+				Namespace:     "default",
+				Repository:    "focom-resources",
+			})
+			assert.Error(t, err)
+			assert.Nil(t, storage)
+		})
+	}
+}
+
+// TestPorchStorageTLS_RejectsCAWithSkipVerify checks that a configured bundle
+// is not silently discarded by the escape hatch.
+func TestPorchStorageTLS_RejectsCAWithSkipVerify(t *testing.T) {
+	isolateClusterEnv(t)
+	server := newPorchTLSServer(t)
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL:         server.URL,
+		Token:                 "test-token",
+		Namespace:             "default",
+		Repository:            "focom-resources",
+		CAFile:                writeCAFile(t, server.Certificate()),
+		InsecureSkipTLSVerify: true,
+	})
+	assert.Error(t, err)
+	assert.Nil(t, storage)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+// TestPorchStorageTLS_CustomTokenInPod checks that a pod which turns off the
+// default token mount and projects its credential elsewhere still starts. The
+// standard token path is deliberately not consulted: everything needed is
+// supplied, so requiring that file as well would refuse a valid deployment.
+func TestPorchStorageTLS_CustomTokenInPod(t *testing.T) {
+	isolateClusterEnv(t)
+	server := newPorchTLSServer(t)
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL: server.URL,
+		Token:         "test-token",
+		Namespace:     "default",
+		Repository:    "focom-resources",
+		CAFile:        writeCAFile(t, server.Certificate()),
+	})
+	require.NoError(t, err)
+	assert.NoError(t, storage.HealthCheck(context.Background()))
+}
+
+// TestPorchStorageTLS_InPodWithoutCAFailsClosed checks that a pod with no CA
+// available refuses to start rather than falling back to the system roots.
+func TestPorchStorageTLS_InPodWithoutCAFailsClosed(t *testing.T) {
+	isolateClusterEnv(t)
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		Token:      "test-token",
+		Namespace:  "default",
+		Repository: "focom-resources",
+	})
+	require.Error(t, err)
+	assert.Nil(t, storage)
+	assert.Contains(t, err.Error(), inClusterCAFile)
+}
+
+// TestPorchStorageTLS_InPodWithMalformedCAFailsClosed checks the bundle at the
+// fixed in-cluster path is loaded rather than merely found. This case only
+// became testable once that path stopped being a constant.
+func TestPorchStorageTLS_InPodWithMalformedCAFailsClosed(t *testing.T) {
+	isolateClusterEnv(t)
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	malformed := filepath.Join(t.TempDir(), "ca.crt")
+	require.NoError(t, os.WriteFile(malformed, []byte("not a certificate\n"), 0600))
+	withInClusterCA(t, malformed)
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		Token:      "test-token",
+		Namespace:  "default",
+		Repository: "focom-resources",
+	})
+	require.Error(t, err)
+	assert.Nil(t, storage)
+}
+
+// TestPorchStorageTLS_PartialServiceEnvIsRefused checks that half an in-cluster
+// environment is a configuration error rather than a silent fallback.
+// TestPorchStorageTLS_OtherEndpointKeepsSystemRoots checks that the cluster
+// bundle follows the cluster's own address. A pod pointed at some other server
+// gets the system roots, so the certificate is still checked, just against the
+// right authorities.
+func TestPorchStorageTLS_OtherEndpointKeepsSystemRoots(t *testing.T) {
+	isolateClusterEnv(t)
+	server := newPorchTLSServer(t)
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL: server.URL,
+		Token:         "test-token",
+		Namespace:     "default",
+		Repository:    "focom-resources",
+	})
+	require.NoError(t, err, "should not have looked for the cluster CA")
+
+	err = storage.HealthCheck(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "certificate")
+}
+
+// TestPorchStorageTLS_ClusterNameUsesClusterCA covers the other spelling of
+// the same server: the in-cluster DNS name is served by the cluster, so it
+// takes the cluster bundle and fails closed without it.
+func TestPorchStorageTLS_ClusterNameUsesClusterCA(t *testing.T) {
+	isolateClusterEnv(t)
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL: defaultKubernetesURL,
+		Token:         "test-token",
+		Namespace:     "default",
+		Repository:    "focom-resources",
+	})
+	require.Error(t, err)
+	assert.Nil(t, storage)
+	assert.Contains(t, err.Error(), inClusterCAFile)
+}
+
+// TestPorchStorageTLS_EquivalentClusterAddresses covers the spellings of the
+// cluster's own endpoint. The certificate does not change with the notation, so
+// neither should the bundle chosen to check it.
+// TestPorchStorageTLS_UnusableHostsAreRefused covers the shapes a second parser reads
+// differently. net/http keeps these as written and the transport maps them
+// before dialling, so the address checked would not be the one used.
+func TestPorchStorageTLS_UnusableHostsAreRefused(t *testing.T) {
+	for _, host := range []string{
+		"https://10.96.0.1%2eevil.example",
+		"https://\u24d4xample.com",
+		"https://ex\uff41mple.com",
+		"https://10.0.0.1\u3002evil",
+		"https://10.96.0.1\\proxy",
+		"https://10.96.0.1 /proxy",
+		"https://10.96.0.1_x",
+		"https://10.96.0.1:0",
+		"https://10.96.0.1:00",
+		"https://10.96.0.1:65536",
+		"https://10.96.0.1:999999999",
+		"https://10.96.0.1?",
+		"https://10.96.0.1#",
+	} {
+		assert.Error(t, validateAPIServerURL(host), "%s should be refused", host)
+	}
+
+	for _, host := range []string{
+		"https://10.96.0.1:443",
+		"https://[fd00::1]:443",
+		"https://kubernetes.default.svc",
+		"https://KUBERNETES.DEFAULT.SVC",
+		"https://example.com.",
+		"https://a-b.example-1.com:6443",
+	} {
+		assert.NoError(t, validateAPIServerURL(host), "%s should be accepted", host)
+	}
+}
+
+// TestPorchStorageTLS_APIServerOrigin pins the helper on its own terms. Its callers happen to
+// have rejected plaintext by the time they reach it, so a caller-level test
+// cannot tell whether the scheme is part of the endpoint. It is.
+func TestPorchStorageTLS_APIServerOrigin(t *testing.T) {
+	same := [][2]string{
+		{"https://10.96.0.1", "https://10.96.0.1:443"},
+		{"https://kubernetes.default.svc", "https://KUBERNETES.DEFAULT.SVC:443"},
+		{"https://[::ffff:a60:1]:443", "https://[0:0:0:0:0:ffff:a60:1]:443"},
+		{"https://host:6443/api", "https://host:6443/healthz"},
+	}
+	for _, pair := range same {
+		assert.Equal(t, apiServerOrigin(pair[0]), apiServerOrigin(pair[1]),
+			"%s and %s are one endpoint", pair[0], pair[1])
+	}
+
+	same = append(same,
+		[2]string{"https://10.96.0.1:443", "https://10.96.0.1:0443"},
+		[2]string{"https://10.96.0.1:443", "https://10.96.0.1:00443"},
+	)
+	for _, pair := range same[len(same)-2:] {
+		assert.Equal(t, apiServerOrigin(pair[0]), apiServerOrigin(pair[1]),
+			"%s and %s are one endpoint", pair[0], pair[1])
+	}
+
+	differ := [][2]string{
+		{"https://10.96.0.1:443", "http://10.96.0.1:443"},
+		{"https://10.96.0.1:443", "https://10.96.0.1:6443"},
+		{"https://10.96.0.1:443", "https://10.96.0.2:443"},
+		{"https://kubernetes.default.svc", "https://kubernetes.default.svc.other"},
+	}
+	for _, pair := range differ {
+		assert.NotEqual(t, apiServerOrigin(pair[0]), apiServerOrigin(pair[1]),
+			"%s and %s are different endpoints", pair[0], pair[1])
+	}
+}
+
+// TestPorchStorageTLS_EmptyCAIsRefused covers a bundle that reads but holds
+// nothing. client-go appends a CA file to an empty pool and keeps the pool
+// only if something was added, so zero bytes leave RootCAs nil and the
+// connection falls back to whatever the image trusts, which is wider than the
+// cluster CA and arrived at without saying so. A file that cannot be parsed
+// was already refused; this is the case between the two.
+func TestPorchStorageTLS_EmptyCAIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	empty := filepath.Join(dir, "empty-ca.crt")
+	require.NoError(t, os.WriteFile(empty, nil, 0o600))
+	usable := writeCAFile(t, newPorchTLSServer(t).Certificate())
+
+	// Not only zero bytes: whatever is installed has to parse, and the file
+	// has to be named, which client-go's own message does not do.
+	for name, content := range map[string]string{
+		"zero bytes":      "",
+		"whitespace only": "   \n\t ",
+		"not a PEM block": "not a certificate\n",
+		"a truncated PEM": "-----BEGIN CERTIFICATE-----\nnope\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			isolateClusterEnv(t)
+			bad := filepath.Join(t.TempDir(), "ca.crt")
+			require.NoError(t, os.WriteFile(bad, []byte(content), 0o600))
+			_, err := NewPorchStorage(&PorchStorageConfig{
+				KubernetesURL: "https://api.example:6443", Token: "t",
+				Namespace: "default", Repository: "focom-resources", CAFile: bad})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), bad)
+			assert.Contains(t, err.Error(), "holds no certificate")
+		})
+	}
+
+	t.Run("from the config", func(t *testing.T) {
+		isolateClusterEnv(t)
+		_, err := NewPorchStorage(&PorchStorageConfig{
+			KubernetesURL: "https://api.example:6443", Token: "t",
+			Namespace: "default", Repository: "focom-resources", CAFile: empty})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), empty)
+	})
+
+	t.Run("from the environment", func(t *testing.T) {
+		isolateClusterEnv(t)
+		t.Setenv("KUBERNETES_CA_FILE", empty)
+		_, err := NewPorchStorage(&PorchStorageConfig{
+			KubernetesURL: "https://api.example:6443", Token: "t",
+			Namespace: "default", Repository: "focom-resources"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), empty)
+	})
+
+	t.Run("mounted in the pod", func(t *testing.T) {
+		isolateClusterEnv(t)
+		withInClusterCA(t, empty)
+		t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+		t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+		_, err := NewPorchStorage(&PorchStorageConfig{
+			Token: "t", Namespace: "default", Repository: "focom-resources"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), empty)
+	})
+
+	t.Run("a usable bundle is untouched", func(t *testing.T) {
+		isolateClusterEnv(t)
+		_, err := NewPorchStorage(&PorchStorageConfig{
+			KubernetesURL: "https://api.example:6443", Token: "t",
+			Namespace: "default", Repository: "focom-resources", CAFile: usable})
+		require.NoError(t, err)
+	})
+
+	t.Run("no bundle keeps the system roots", func(t *testing.T) {
+		isolateClusterEnv(t)
+		_, err := NewPorchStorage(&PorchStorageConfig{
+			KubernetesURL: "https://other.example:6443", Token: "t",
+			Namespace: "default", Repository: "focom-resources"})
+		require.NoError(t, err)
+	})
+}
+
+// TestPorchStorageTLS_LeadingZeroPortStillNeedsTheClusterCA is the constructor
+// half of the origin comparison: ":0443" is the advertised endpoint however it
+// is spelled, so it has to ask for the same bundle.
+func TestPorchStorageTLS_LeadingZeroPortStillNeedsTheClusterCA(t *testing.T) {
+	isolateClusterEnv(t)
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL: "https://10.96.0.1:0443",
+		Token:         "test-token",
+		Namespace:     "default",
+		Repository:    "focom-resources",
+	})
+	require.Error(t, err)
+	assert.Nil(t, storage)
+	assert.Contains(t, err.Error(), inClusterCAFile)
+}
+
+// TestPorchStorageTLS_RequestPathSurvivesTheBaseURL covers the join. A base
+// URL ending in "/" produced "//apis", which the API server answers with a
+// redirect, and a proxy prefix has to survive.
+func TestPorchStorageTLS_RequestPathSurvivesTheBaseURL(t *testing.T) {
+	for _, suffix := range []string{"", "/", "/proxy", "/proxy/"} {
+		t.Run("base"+suffix, func(t *testing.T) {
+			var got string
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = r.URL.Path
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{"items": []interface{}{}})
+			}))
+			defer server.Close()
+
+			storage := &PorchStorage{
+				httpClient: server.Client(), kubernetesURL: server.URL + suffix,
+				namespace: "default", repository: "focom-resources"}
+			require.NoError(t, storage.HealthCheck(context.Background()))
+
+			want := strings.TrimSuffix(suffix, "/") +
+				"/apis/porch.kpt.dev/v1alpha1/namespaces/default/packagerevisions"
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+// TestPorchStorageTLS_UnusableEndpointIsRefusedBeforeTheCA checks the order.
+// Which bundle an address gets is a decision about an endpoint, so an endpoint
+// that cannot carry a token has to be refused first: the origin comparison
+// ignores everything but scheme, host and port, and would otherwise hand the
+// cluster CA to a plaintext address on its way to being rejected anyway.
+func TestPorchStorageTLS_UnusableEndpointIsRefusedBeforeTheCA(t *testing.T) {
+	isolateClusterEnv(t)
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+	withInClusterCA(t, writeCAFile(t, newPorchTLSServer(t).Certificate()))
+
+	restConfig, err := buildRESTConfig(&PorchStorageConfig{
+		KubernetesURL: "http://10.96.0.1:443",
+	})
+	require.Error(t, err)
+	assert.Nil(t, restConfig)
+	assert.Contains(t, err.Error(), "must use https")
+}
+
+func TestPorchStorageTLS_EquivalentClusterAddresses(t *testing.T) {
+	for _, kubernetesURL := range []string{
+		"https://10.96.0.1:443",
+		"https://10.96.0.1",
+		"https://kubernetes.default.svc",
+		"https://kubernetes.default.svc:443",
+		"https://KUBERNETES.DEFAULT.SVC",
+		"https://[::ffff:10.96.0.1]:443",
+	} {
+		t.Run(kubernetesURL, func(t *testing.T) {
+			isolateClusterEnv(t)
+			t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+			t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+			storage, err := NewPorchStorage(&PorchStorageConfig{
+				KubernetesURL: kubernetesURL,
+				Token:         "test-token",
+				Namespace:     "default",
+				Repository:    "focom-resources",
+			})
+			require.Error(t, err)
+			assert.Nil(t, storage)
+			assert.Contains(t, err.Error(), inClusterCAFile,
+				"should have chosen the cluster bundle for %s", kubernetesURL)
+		})
+	}
+}
+
+func TestPorchStorageTLS_PartialServiceEnvIsRefused(t *testing.T) {
+	isolateClusterEnv(t)
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		Token:      "test-token",
+		Namespace:  "default",
+		Repository: "focom-resources",
+	})
+	require.Error(t, err)
+	assert.Nil(t, storage)
+	assert.Contains(t, err.Error(), "must be set together")
+}
+
+// TestPorchStorageTLS_SkipVerifyOptIn checks the development escape hatch.
+func TestPorchStorageTLS_SkipVerifyOptIn(t *testing.T) {
+	isolateClusterEnv(t)
+	server := newPorchTLSServer(t)
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL:         server.URL,
+		Token:                 "test-token",
+		Namespace:             "default",
+		Repository:            "focom-resources",
+		InsecureSkipTLSVerify: true,
+	})
+	require.NoError(t, err)
+
+	assert.NoError(t, storage.HealthCheck(context.Background()))
 }
 
 // TEMPORARY TEST - TestHealthCheck_Success tests successful health check

--- a/operators/focom-operator/internal/nbi/storage/porch_test.go
+++ b/operators/focom-operator/internal/nbi/storage/porch_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/nephio-project/nephio/operators/focom-operator/internal/nbi/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
 )
 
 // ============================================================================
@@ -60,6 +61,7 @@ import (
 
 // TEMPORARY TEST - TestNewPorchStorage_WithConfig tests initialization with explicit config
 func TestNewPorchStorage_WithConfig(t *testing.T) {
+	isolateClusterEnv(t)
 	config := &PorchStorageConfig{
 		KubernetesURL: "https://test-k8s-api:6443",
 		Token:         "test-token-12345",
@@ -71,7 +73,6 @@ func TestNewPorchStorage_WithConfig(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, storage)
 	assert.Equal(t, "https://test-k8s-api:6443", storage.kubernetesURL)
-	assert.Equal(t, "test-token-12345", storage.token)
 	assert.Equal(t, "test-namespace", storage.namespace)
 	assert.Equal(t, "test-repo", storage.repository)
 	assert.NotNil(t, storage.httpClient)
@@ -80,6 +81,7 @@ func TestNewPorchStorage_WithConfig(t *testing.T) {
 
 // TEMPORARY TEST - TestNewPorchStorage_WithEnvVars tests initialization with environment variables
 func TestNewPorchStorage_WithEnvVars(t *testing.T) {
+	isolateClusterEnv(t)
 	// Set environment variables
 	os.Setenv("KUBERNETES_BASE_URL", "https://env-k8s-api:6443")
 	os.Setenv("TOKEN", "env-token-67890")
@@ -94,11 +96,11 @@ func TestNewPorchStorage_WithEnvVars(t *testing.T) {
 	storage, err := NewPorchStorage(config)
 	require.NoError(t, err)
 	assert.Equal(t, "https://env-k8s-api:6443", storage.kubernetesURL)
-	assert.Equal(t, "env-token-67890", storage.token)
 }
 
 // TEMPORARY TEST - TestNewPorchStorage_WithTokenFile tests token resolution from file
 func TestNewPorchStorage_WithTokenFile(t *testing.T) {
+	isolateClusterEnv(t)
 	// Create temporary token file
 	tmpDir := t.TempDir()
 	tokenFile := filepath.Join(tmpDir, "token")
@@ -118,7 +120,8 @@ func TestNewPorchStorage_WithTokenFile(t *testing.T) {
 
 	storage, err := NewPorchStorage(config)
 	require.NoError(t, err)
-	assert.Equal(t, tokenContent, storage.token)
+	assert.Equal(t, "https://test-k8s-api:6443", storage.kubernetesURL)
+	assert.NotNil(t, storage.httpClient)
 }
 
 // TEMPORARY TEST - TestNewPorchStorage_DefaultKubernetesURL tests default Kubernetes URL
@@ -141,6 +144,7 @@ func TestNewPorchStorage_DefaultKubernetesURL(t *testing.T) {
 
 // TEMPORARY TEST - TestNewPorchStorage_MissingNamespace tests validation of required fields
 func TestNewPorchStorage_MissingNamespace(t *testing.T) {
+	isolateClusterEnv(t)
 	config := &PorchStorageConfig{
 		Token:      "test-token",
 		Repository: "focom-resources",
@@ -155,6 +159,7 @@ func TestNewPorchStorage_MissingNamespace(t *testing.T) {
 
 // TEMPORARY TEST - TestNewPorchStorage_MissingRepository tests validation of required fields
 func TestNewPorchStorage_MissingRepository(t *testing.T) {
+	isolateClusterEnv(t)
 	config := &PorchStorageConfig{
 		Token:     "test-token",
 		Namespace: "default",
@@ -184,6 +189,7 @@ func TestMain(m *testing.M) {
 		"KUBERNETES_CA_FILE",
 		"UNSAFE_SKIP_TLS_VERIFY",
 		"PORCH_HTTPS_VERIFY",
+		"TOKEN",
 	} {
 		if err := os.Unsetenv(key); err != nil {
 			panic(err)
@@ -202,9 +208,18 @@ func isolateClusterEnv(t *testing.T) {
 	// The default path is a real file in any pod that mounts the service
 	// account credential, so a test that assumes its absence would behave one
 	// way on a laptop and the other way in CI. Point it somewhere empty.
-	original := inClusterCAFile
-	inClusterCAFile = filepath.Join(t.TempDir(), "absent-ca.crt")
-	t.Cleanup(func() { inClusterCAFile = original })
+	dir := t.TempDir()
+	originalCA, originalToken := inClusterCAFile, inClusterTokenFile
+	inClusterCAFile = filepath.Join(dir, "absent-ca.crt")
+	// The token beside it is the same problem, and now that the path is a
+	// variable it can be moved too. Without this, two pre-existing kubeconfig
+	// tests find the real mounted token and stop returning the error they
+	// assert; they fail on main inside any pod carrying the credential.
+	inClusterTokenFile = filepath.Join(dir, "absent-token")
+	t.Cleanup(func() {
+		inClusterCAFile = originalCA
+		inClusterTokenFile = originalToken
+	})
 }
 
 // withInClusterCA points the fixed in-cluster CA path at the given file for the
@@ -552,6 +567,13 @@ func TestPorchStorageTLS_APIServerOrigin(t *testing.T) {
 		assert.NotEqual(t, apiServerOrigin(pair[0]), apiServerOrigin(pair[1]),
 			"%s and %s are different endpoints", pair[0], pair[1])
 	}
+
+	// Nothing reaches this in the operator, since the endpoint is validated
+	// before the bundle is chosen, but a helper that cannot answer should say
+	// so by returning the input rather than a plausible wrong origin.
+	for _, unusable := range []string{"https://h:65536", "https://h:abc", "https://[bad"} {
+		assert.Equal(t, unusable, apiServerOrigin(unusable))
+	}
 }
 
 // TestPorchStorageTLS_EmptyCAIsRefused covers a bundle that reads but holds
@@ -757,6 +779,213 @@ func TestPorchStorageTLS_SkipVerifyOptIn(t *testing.T) {
 	assert.NoError(t, storage.HealthCheck(context.Background()))
 }
 
+// TestPorchStorageAuth_TransportSigns is the whole point of this change: the token
+// reaches the API server without makeRequest writing the header, which is what
+// let client-go's credential wrappers run.
+//
+// Rotation itself is not asserted here. client-go caches a token file for a
+// minute, so a test of that costs a minute of CI to watch one boolean. What is
+// asserted is the half that decides it: resolveCredentials hands over the path
+// rather than the contents, in TestPorchStorageAuth_ResolvesCredentials.
+func TestPorchStorageAuth_TransportSigns(t *testing.T) {
+	isolateClusterEnv(t)
+
+	var seen string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"items": []interface{}{}})
+	}))
+	defer server.Close()
+
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("token-from-the-file\n"), 0o600))
+	t.Setenv("TOKEN", tokenFile)
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL: server.URL,
+		Namespace:     "default",
+		Repository:    "focom-resources",
+		CAFile:        writeCAFile(t, server.Certificate()),
+	})
+	require.NoError(t, err)
+	require.NoError(t, storage.HealthCheck(context.Background()))
+
+	// trailing newline trimmed by client-go, not by us
+	assert.Equal(t, "Bearer token-from-the-file", seen)
+}
+
+// TestPorchStorageAuth_ExecPluginIsRun covers the other half of what the manual header
+// suppressed. Under a kubeconfig the token was empty, so the header read
+// "Bearer " with nothing after it, which is still a header, and client-go's
+// exec wrapper returns early on one. Putting the header back makes the server
+// see "Bearer" here instead of the plugin's token.
+func TestPorchStorageAuth_ExecPluginIsRun(t *testing.T) {
+	isolateClusterEnv(t)
+
+	var seen string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"items": []interface{}{}})
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	plugin := filepath.Join(dir, "credential-plugin.sh")
+	require.NoError(t, os.WriteFile(plugin, []byte("#!/bin/sh\n"+
+		`echo '{"apiVersion":"client.authentication.k8s.io/v1","kind":"ExecCredential",`+
+		`"status":{"token":"token-from-exec-plugin"}}'`+"\n"), 0o700))
+
+	kubeconfig := filepath.Join(dir, "config")
+	require.NoError(t, os.WriteFile(kubeconfig, fmt.Appendf(nil,
+		"apiVersion: v1\nkind: Config\nclusters:\n- name: c\n  cluster:\n"+
+			"    server: %s\n    certificate-authority: %s\n"+
+			"contexts:\n- name: c\n  context:\n    cluster: c\n    user: u\n"+
+			"current-context: c\nusers:\n- name: u\n  user:\n    exec:\n"+
+			"      apiVersion: client.authentication.k8s.io/v1\n"+
+			"      command: %s\n      interactiveMode: Never\n",
+		server.URL, writeCAFile(t, server.Certificate()), plugin), 0o600))
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		UseKubeconfig: true,
+		Kubeconfig:    kubeconfig,
+		Namespace:     "default",
+		Repository:    "focom-resources",
+	})
+	require.NoError(t, err)
+	require.NoError(t, storage.HealthCheck(context.Background()))
+	assert.Equal(t, "Bearer token-from-exec-plugin", seen)
+}
+
+// TestPorchStorageAuth_EmptyTokenFileFailsClosed covers a behaviour change.
+// Reading the file here used to produce an empty string and an Authorization
+// of "Bearer " with nothing after it, which the API server answers with an
+// opaque 401. client-go refuses the file instead, so it is a startup failure
+// naming the path.
+func TestPorchStorageAuth_EmptyTokenFileFailsClosed(t *testing.T) {
+	for name, content := range map[string]string{
+		"empty": "", "blank": "  \n\t ",
+	} {
+		t.Run(name, func(t *testing.T) {
+			isolateClusterEnv(t)
+			tokenFile := filepath.Join(t.TempDir(), "token")
+			require.NoError(t, os.WriteFile(tokenFile, []byte(content), 0o600))
+			t.Setenv("TOKEN", tokenFile)
+
+			storage, err := NewPorchStorage(&PorchStorageConfig{
+				KubernetesURL: "https://api.example:6443",
+				Namespace:     "default",
+				Repository:    "focom-resources",
+				CAFile:        writeCAFile(t, newPorchTLSServer(t).Certificate()),
+			})
+			require.Error(t, err)
+			assert.Nil(t, storage)
+			assert.Contains(t, err.Error(), tokenFile)
+		})
+	}
+}
+
+// TestPorchStorageAuth_SharedClientIsRefused covers a guard I first wrote as
+// unreachable and then found is not. rest.HTTPClientFor hands back
+// http.DefaultClient for a config with no TLS, credentials or timeout, and
+// setting CheckRedirect on that would reach every other user of the process.
+func TestPorchStorageAuth_SharedClientIsRefused(t *testing.T) {
+	bare := &rest.Config{Host: "https://api.example:6443"}
+
+	shared, err := rest.HTTPClientFor(bare)
+	require.NoError(t, err)
+	require.Same(t, http.DefaultClient, shared, "the premise of the guard")
+
+	client, err := newHTTPClient(bare)
+	require.Error(t, err)
+	assert.Nil(t, client)
+	assert.Nil(t, http.DefaultClient.CheckRedirect, "left alone")
+}
+
+// TestPorchStorageAuth_TokenSymlinkIsFollowed matters because that is the
+// shape a projected volume has: the mounted token is a symlink into ..data,
+// and the kubelet rotates by swapping where the link points.
+func TestPorchStorageAuth_TokenSymlinkIsFollowed(t *testing.T) {
+	isolateClusterEnv(t)
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "..2026_09_08_token")
+	require.NoError(t, os.WriteFile(target, []byte("token-behind-the-link"), 0o600))
+	link := filepath.Join(dir, "token")
+	require.NoError(t, os.Symlink(target, link))
+
+	var seen string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"items": []interface{}{}})
+	}))
+	defer server.Close()
+
+	t.Setenv("TOKEN", link)
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL: server.URL,
+		Namespace:     "default",
+		Repository:    "focom-resources",
+		CAFile:        writeCAFile(t, server.Certificate()),
+	})
+	require.NoError(t, err)
+	require.NoError(t, storage.HealthCheck(context.Background()))
+	assert.Equal(t, "Bearer token-behind-the-link", seen)
+}
+
+// TestPorchStorageAuth_RedirectIsRefused pins the cost of moving the header
+// onto the transport. net/http drops an Authorization header the caller set
+// when a redirect crosses hosts, and cannot drop one a RoundTripper adds on
+// the next hop, so the token would otherwise reach wherever the API server
+// pointed. Porch is an aggregated API server, which is the position
+// CVE-2022-3172 describes.
+func TestPorchStorageAuth_RedirectIsRefused(t *testing.T) {
+	isolateClusterEnv(t)
+
+	elsewhereSaw := "<no request>"
+	elsewhere := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		elsewhereSaw = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer elsewhere.Close()
+	// a different host as far as net/http is concerned, not just a different port
+	elsewhereURL := strings.Replace(elsewhere.URL, "127.0.0.1", "localhost", 1)
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, elsewhereURL+"/somewhere-else", http.StatusFound)
+	}))
+	defer server.Close()
+
+	storage, err := NewPorchStorage(&PorchStorageConfig{
+		KubernetesURL: server.URL,
+		Token:         "test-token",
+		Namespace:     "default",
+		Repository:    "focom-resources",
+		CAFile:        writeCAFile(t, server.Certificate()),
+	})
+	require.NoError(t, err)
+
+	err = storage.HealthCheck(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to follow a redirect")
+	assert.Equal(t, "<no request>", elsewhereSaw, "nothing should have been sent")
+}
+
+// signingClient builds the client the way the constructors do, so a test that
+// asserts on Authorization is asserting on what the transport produced.
+func signingClient(t *testing.T, server *httptest.Server, token string) *http.Client {
+	t.Helper()
+	client, err := rest.HTTPClientFor(&rest.Config{
+		Host:            server.URL,
+		BearerToken:     token,
+		TLSClientConfig: rest.TLSClientConfig{Insecure: true},
+	})
+	require.NoError(t, err)
+	return client
+}
+
 // TEMPORARY TEST - TestHealthCheck_Success tests successful health check
 func TestHealthCheck_Success(t *testing.T) {
 	// Create mock HTTP server
@@ -779,9 +1008,8 @@ func TestHealthCheck_Success(t *testing.T) {
 	defer server.Close()
 
 	storage := &PorchStorage{
-		httpClient:    server.Client(),
+		httpClient:    signingClient(t, server, "test-token"),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "focom-resources",
 	}
@@ -801,7 +1029,6 @@ func TestHealthCheck_Unauthorized(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "invalid-token",
 		namespace:     "default",
 		repository:    "focom-resources",
 	}
@@ -826,7 +1053,6 @@ func TestHealthCheck_ServerError(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "focom-resources",
 	}
@@ -852,7 +1078,6 @@ func TestHealthCheck_Timeout(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "focom-resources",
 	}
@@ -887,9 +1112,8 @@ func TestMakeRequest_WithBody(t *testing.T) {
 	defer server.Close()
 
 	storage := &PorchStorage{
-		httpClient:    server.Client(),
+		httpClient:    signingClient(t, server, "test-token"),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "focom-resources",
 	}
@@ -920,7 +1144,6 @@ func TestMakeRequest_WithoutBody(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "focom-resources",
 	}
@@ -934,6 +1157,7 @@ func TestMakeRequest_WithoutBody(t *testing.T) {
 
 // TEMPORARY TEST - TestNewPorchStorage_WithKubeconfig tests token resolution from kubeconfig file
 func TestNewPorchStorage_WithKubeconfig(t *testing.T) {
+	isolateClusterEnv(t)
 	// Create temporary kubeconfig file
 	tmpDir := t.TempDir()
 	kubeconfigFile := filepath.Join(tmpDir, "config")
@@ -974,7 +1198,6 @@ users:
 
 	storage, err := NewPorchStorage(config)
 	require.NoError(t, err)
-	assert.Equal(t, "kubeconfig-token-xyz123", storage.token)
 	// Note: We don't extract the server URL from kubeconfig, only the token
 	// The URL still comes from KUBERNETES_BASE_URL env var or defaults to in-cluster
 	assert.Equal(t, "https://kubernetes.default.svc", storage.kubernetesURL)
@@ -982,12 +1205,16 @@ users:
 
 // TEMPORARY TEST - TestNewPorchStorage_KubeconfigNotFound tests error when kubeconfig doesn't exist
 func TestNewPorchStorage_KubeconfigNotFound(t *testing.T) {
+	// Without this the mounted token is found before the kubeconfig is
+	// reached, and no error comes back. That is why this fails on main
+	// inside any pod carrying the service account credential.
+	isolateClusterEnv(t)
+
 	// Set KUBECONFIG to non-existent file
-	os.Setenv("KUBECONFIG", "/tmp/nonexistent-kubeconfig-12345")
-	defer os.Unsetenv("KUBECONFIG")
+	t.Setenv("KUBECONFIG", "/tmp/nonexistent-kubeconfig-12345")
 
 	// Ensure TOKEN env var is not set
-	os.Unsetenv("TOKEN")
+	require.NoError(t, os.Unsetenv("TOKEN"))
 
 	config := &PorchStorageConfig{
 		Namespace:  "default",
@@ -1002,6 +1229,7 @@ func TestNewPorchStorage_KubeconfigNotFound(t *testing.T) {
 
 // TEMPORARY TEST - TestNewPorchStorage_KubeconfigNoToken tests error when kubeconfig has no token
 func TestNewPorchStorage_KubeconfigNoToken(t *testing.T) {
+	isolateClusterEnv(t)
 	// Create temporary kubeconfig file without token
 	tmpDir := t.TempDir()
 	kubeconfigFile := filepath.Join(tmpDir, "config")
@@ -1049,77 +1277,118 @@ users:
 }
 
 // TEMPORARY TEST - TestResolveToken_Priority tests the token resolution priority order
-func TestResolveToken_Priority(t *testing.T) {
-	// Test 1: TOKEN env var takes priority over everything
-	t.Run("TOKEN_EnvVar_Priority", func(t *testing.T) {
-		os.Setenv("TOKEN", "env-token-priority")
-		defer os.Unsetenv("TOKEN")
-
-		// Create a kubeconfig that would also work
-		tmpDir := t.TempDir()
-		kubeconfigFile := filepath.Join(tmpDir, "config")
-		kubeconfigContent := `
+// TestPorchStorageAuth_ResolvesCredentials covers where the token comes from, and in which form.
+// The old version of this asserted on a string field that no longer exists, and
+// faked the in-cluster path by pointing TOKEN at a file, so it never reached
+// the branch it was named after.
+func TestPorchStorageAuth_ResolvesCredentials(t *testing.T) {
+	kubeconfig := `
 apiVersion: v1
 kind: Config
 users:
 - name: test-user
   user:
-    token: kubeconfig-token-should-not-be-used
+    token: kubeconfig-token
 `
-		os.WriteFile(kubeconfigFile, []byte(kubeconfigContent), 0600)
-		os.Setenv("KUBECONFIG", kubeconfigFile)
-		defer os.Unsetenv("KUBECONFIG")
+	cases := map[string]struct {
+		config       *PorchStorageConfig
+		tokenEnv     string // "" leaves TOKEN unset; "@file" means a path
+		inClusterSet bool
+		wantToken    string
+		wantFile     string // "@file" for the temporary path, "@incluster" for the mounted one
+		wantErr      string // when set, resolveCredentials has to refuse
+	}{
+		"an explicit token is used as it is": {
+			config:    &PorchStorageConfig{Token: "explicit"},
+			wantToken: "explicit",
+		},
+		"TOKEN naming a file is followed rather than read": {
+			config:   &PorchStorageConfig{},
+			tokenEnv: "@file",
+			wantFile: "@file",
+		},
+		// "@missing" and not the real mount path: that file exists inside a
+		// pod, and this case would then resolve instead of being refused.
+		"TOKEN naming an absolute path that is not there is refused": {
+			config:   &PorchStorageConfig{},
+			tokenEnv: "@missing",
+			wantErr:  "cannot be used",
+		},
+		// a token in standard base64 carries a separator and used to work
+		"TOKEN holding a token with a slash is still a token": {
+			config:    &PorchStorageConfig{},
+			tokenEnv:  "a/b+c==",
+			wantToken: "a/b+c==",
+		},
+		"TOKEN holding a token is used as it is": {
+			config:    &PorchStorageConfig{},
+			tokenEnv:  "literal-token",
+			wantToken: "literal-token",
+		},
+		"the mounted token is followed rather than read": {
+			config:       &PorchStorageConfig{},
+			inClusterSet: true,
+			wantFile:     "@incluster",
+		},
+		"the kubeconfig is the last resort": {
+			config:    &PorchStorageConfig{},
+			wantToken: "kubeconfig-token",
+		},
+	}
 
-		config := &PorchStorageConfig{
-			Namespace:  "default",
-			Repository: "focom-resources",
-		}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			tokenPath := filepath.Join(dir, "projected-token")
+			require.NoError(t, os.WriteFile(tokenPath, []byte("from-a-file"), 0o600))
 
-		storage, err := NewPorchStorage(config)
-		require.NoError(t, err)
-		assert.Equal(t, "env-token-priority", storage.token, "TOKEN env var should take priority")
-	})
+			kubeconfigPath := filepath.Join(dir, "config")
+			require.NoError(t, os.WriteFile(kubeconfigPath, []byte(kubeconfig), 0o600))
+			t.Setenv("KUBECONFIG", kubeconfigPath)
 
-	// Test 2: In-cluster token file takes priority over kubeconfig
-	t.Run("InCluster_Priority_Over_Kubeconfig", func(t *testing.T) {
-		// Ensure TOKEN env var is not set
-		os.Unsetenv("TOKEN")
+			// somewhere that does not exist unless the case asks for it
+			inCluster := filepath.Join(dir, "mounted-token")
+			if tc.inClusterSet {
+				require.NoError(t, os.WriteFile(inCluster, []byte("from-the-mount"), 0o600))
+			}
+			original := inClusterTokenFile
+			inClusterTokenFile = inCluster
+			t.Cleanup(func() { inClusterTokenFile = original })
 
-		// Create a temporary in-cluster token file
-		tmpDir := t.TempDir()
-		inClusterTokenFile := filepath.Join(tmpDir, "token")
-		os.WriteFile(inClusterTokenFile, []byte("in-cluster-token"), 0600)
+			switch tc.tokenEnv {
+			case "":
+				t.Setenv("TOKEN", "")
+				require.NoError(t, os.Unsetenv("TOKEN"))
+			case "@file":
+				t.Setenv("TOKEN", tokenPath)
+			case "@missing":
+				t.Setenv("TOKEN", filepath.Join(dir, "not-created"))
+			default:
+				t.Setenv("TOKEN", tc.tokenEnv)
+			}
 
-		// Create a kubeconfig
-		kubeconfigFile := filepath.Join(tmpDir, "config")
-		kubeconfigContent := `
-apiVersion: v1
-kind: Config
-users:
-- name: test-user
-  user:
-    token: kubeconfig-token-should-not-be-used
-`
-		os.WriteFile(kubeconfigFile, []byte(kubeconfigContent), 0600)
-		os.Setenv("KUBECONFIG", kubeconfigFile)
-		defer os.Unsetenv("KUBECONFIG")
+			restConfig := &rest.Config{}
+			err := resolveCredentials(tc.config, restConfig)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
 
-		// Mock the in-cluster token path by setting TOKEN to the file path
-		os.Setenv("TOKEN", inClusterTokenFile)
-		defer os.Unsetenv("TOKEN")
-
-		config := &PorchStorageConfig{
-			Namespace:  "default",
-			Repository: "focom-resources",
-		}
-
-		storage, err := NewPorchStorage(config)
-		require.NoError(t, err)
-		assert.Equal(t, "in-cluster-token", storage.token, "In-cluster token should take priority over kubeconfig")
-	})
+			wantFile := tc.wantFile
+			switch wantFile {
+			case "@file":
+				wantFile = tokenPath
+			case "@incluster":
+				wantFile = inCluster
+			}
+			assert.Equal(t, tc.wantToken, restConfig.BearerToken)
+			assert.Equal(t, wantFile, restConfig.BearerTokenFile)
+		})
+	}
 }
 
-// TEMPORARY TEST - TestParseResponse_Success tests successful response parsing
 func TestParseResponse_Success(t *testing.T) {
 	storage := &PorchStorage{}
 
@@ -1701,7 +1970,6 @@ func TestCreateDraft_Success(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -1745,7 +2013,6 @@ func TestCreateDraft_AlreadyExists(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -1830,7 +2097,6 @@ spec:
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -1868,7 +2134,6 @@ func TestGetDraft_NotFound(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -1944,7 +2209,6 @@ spec:
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -2011,7 +2275,6 @@ func TestGetDraft_MissingResourceFile(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -2105,7 +2368,6 @@ func TestUpdateDraft_Success(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -2141,7 +2403,6 @@ func TestUpdateDraft_NotFound(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -2186,7 +2447,6 @@ func TestUpdateDraft_InvalidState(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -2277,7 +2537,6 @@ func TestUpdateDraft_TemplateInfo(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -2343,7 +2602,6 @@ func TestDeleteDraft_Success(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -2369,7 +2627,6 @@ func TestDeleteDraft_NotFound(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -2411,7 +2668,6 @@ func TestDeleteDraft_InvalidState(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -2463,7 +2719,6 @@ func TestDeleteDraft_ProposedState(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -2511,7 +2766,6 @@ func TestDeleteDraft_NoContent(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -2615,7 +2869,6 @@ spec:
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -2641,7 +2894,6 @@ func TestValidateDraft_NotFound(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -2682,7 +2934,6 @@ func TestValidateDraft_InvalidState(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -2743,7 +2994,6 @@ func TestValidateDraft_TemplateInfo(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -2818,7 +3068,6 @@ func TestApproveDraft_Success(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -2899,7 +3148,6 @@ func TestApproveDraft_WithExistingRevisions(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -2924,7 +3172,6 @@ func TestApproveDraft_NotFound(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -2965,7 +3212,6 @@ func TestApproveDraft_InvalidState(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -3030,7 +3276,6 @@ func TestRejectDraft_Success(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -3056,7 +3301,6 @@ func TestRejectDraft_NotFound(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -3097,7 +3341,6 @@ func TestRejectDraft_InvalidState(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -3157,7 +3400,6 @@ func TestRejectDraft_TemplateInfo(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -3226,7 +3468,6 @@ func TestCreate_Success(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -3271,7 +3512,6 @@ func TestCreate_AlreadyExists(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -3331,7 +3571,6 @@ func TestCreate_TemplateInfo(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -3425,7 +3664,6 @@ spec:
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -3458,7 +3696,6 @@ func TestGet_NotFound(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -3556,7 +3793,6 @@ spec:
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -3698,7 +3934,6 @@ func TestUpdate_Success(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -3735,7 +3970,6 @@ func TestUpdate_NotFound(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -3825,7 +4059,6 @@ func TestDelete_Success(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -3855,7 +4088,6 @@ func TestDelete_NoRevisions(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -3911,7 +4143,6 @@ func TestDelete_OnlyPublished(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -4004,7 +4235,6 @@ spec:
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -4037,7 +4267,6 @@ func TestList_Empty(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -4124,7 +4353,6 @@ spec:
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -4221,7 +4449,6 @@ spec:
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -4256,7 +4483,6 @@ func TestGetRevisions_Empty(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -4318,7 +4544,6 @@ spec:
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -4397,7 +4622,6 @@ spec:
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -4438,7 +4662,6 @@ func TestGetRevision_NotFound(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -4480,7 +4703,6 @@ func TestGetRevision_InvalidRevisionID(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -4569,7 +4791,6 @@ spec:
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -4601,7 +4822,6 @@ func TestCreateDraftFromRevision_AlreadyExists(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -4648,7 +4868,6 @@ func TestCreateDraftFromRevision_InvalidRevision(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -4730,7 +4949,6 @@ spec:
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -4761,7 +4979,6 @@ func TestValidateDependencies_FPRCreate_MissingOCloud(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -4841,7 +5058,6 @@ spec:
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -4878,7 +5094,6 @@ func TestValidateDependencies_OCloudDelete_NoReferences(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -4955,7 +5170,6 @@ spec:
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -5036,7 +5250,6 @@ spec:
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -5074,7 +5287,6 @@ func TestValidateDependencies_TemplateInfoDelete_NoReferences(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -5161,7 +5373,6 @@ spec:
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}
@@ -5240,7 +5451,6 @@ func TestValidateDependencies_InvalidResourceType(t *testing.T) {
 	storage := &PorchStorage{
 		httpClient:    server.Client(),
 		kubernetesURL: server.URL,
-		token:         "test-token",
 		namespace:     "default",
 		repository:    "test-repo",
 	}

--- a/operators/focom-operator/internal/nbi/testconfig.go
+++ b/operators/focom-operator/internal/nbi/testconfig.go
@@ -39,13 +39,16 @@ type StorageConfig struct {
 
 // PorchConfig holds Porch-specific configuration
 type PorchConfig struct {
-	UseKubeconfig bool   `yaml:"useKubeconfig,omitempty"` // Use kubeconfig for auth (handles exec, certs, etc.)
+	UseKubeconfig bool   `yaml:"useKubeconfig,omitempty"` // Use kubeconfig for auth (client certs; exec plugins are not yet honoured)
 	Kubeconfig    string `yaml:"kubeconfig,omitempty"`    // Path to kubeconfig (optional, auto-detected)
 	KubernetesURL string `yaml:"kubernetesURL,omitempty"` // Optional, auto-detected from KUBECONFIG
 	Token         string `yaml:"token,omitempty"`         // Optional, auto-detected
 	Namespace     string `yaml:"namespace"`
 	Repository    string `yaml:"repository"`
-	HTTPSVerify   bool   `yaml:"httpsVerify"`
+	CAFile        string `yaml:"caFile,omitempty"` // PEM bundle verifying the API server (optional)
+	// InsecureSkipTLSVerify skips verification of the API server certificate.
+	// Development only; the zero value verifies.
+	InsecureSkipTLSVerify bool `yaml:"insecureSkipTLSVerify,omitempty"`
 }
 
 // TestOptions holds test execution options
@@ -63,9 +66,8 @@ func DefaultTestConfig() *TestConfig {
 			Backend: "memory",
 		},
 		Porch: PorchConfig{
-			Namespace:   "default",
-			Repository:  "focom-resources",
-			HTTPSVerify: false,
+			Namespace:  "default",
+			Repository: "focom-resources",
 		},
 		Test: TestOptions{
 			Cleanup:        true,

--- a/operators/focom-operator/internal/nbi/testconfig.go
+++ b/operators/focom-operator/internal/nbi/testconfig.go
@@ -39,7 +39,7 @@ type StorageConfig struct {
 
 // PorchConfig holds Porch-specific configuration
 type PorchConfig struct {
-	UseKubeconfig bool   `yaml:"useKubeconfig,omitempty"` // Use kubeconfig for auth (client certs; exec plugins are not yet honoured)
+	UseKubeconfig bool   `yaml:"useKubeconfig,omitempty"` // Use kubeconfig for auth (client certs, tokens and exec plugins)
 	Kubeconfig    string `yaml:"kubeconfig,omitempty"`    // Path to kubeconfig (optional, auto-detected)
 	KubernetesURL string `yaml:"kubernetesURL,omitempty"` // Optional, auto-detected from KUBECONFIG
 	Token         string `yaml:"token,omitempty"`         // Optional, auto-detected

--- a/operators/focom-operator/internal/nbi/testconfig.yaml.example
+++ b/operators/focom-operator/internal/nbi/testconfig.yaml.example
@@ -42,9 +42,14 @@ porch:
   
   # Porch repository name
   repository: focom-resources
-  
-  # Verify HTTPS certificates (set to true for production)
-  httpsVerify: false
+
+  # PEM bundle used to verify the API server certificate. Optional: in-cluster
+  # the service account CA is used, and a kubeconfig carries its own CA.
+  # caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+  # Skip verification of the API server certificate. Development only: the
+  # bearer token is then exposed to anyone able to intercept the connection.
+  # insecureSkipTLSVerify: false
 
 # Test execution options
 test:
@@ -74,8 +79,8 @@ test:
 # porch:
 #   namespace: default
 #   repository: focom-resources-test
-#   httpsVerify: false
-# # Token and kubernetesURL will be auto-detected from KUBECONFIG
+# # Only the token is taken from KUBECONFIG unless useKubeconfig: true is set;
+# # kubernetesURL and the CA are not. See the note on useKubeconfig above.
 
 # Example 3: CI/CD with Porch storage (use environment variables)
 # export NBI_STORAGE_BACKEND=porch

--- a/operators/focom-operator/kpt-package/focom-operator-bundle.yaml
+++ b/operators/focom-operator/kpt-package/focom-operator-bundle.yaml
@@ -667,10 +667,6 @@ spec:
           value: default
         - name: PORCH_REPOSITORY
           value: focom-resources
-        - name: KUBERNETES_BASE_URL
-          value: https://kubernetes.default.svc
-        - name: PORCH_HTTPS_VERIFY
-          value: "false"
         image: docker.io/nephio/focom-operator:latest
         imagePullPolicy: Always
         livenessProbe:


### PR DESCRIPTION
`makeRequest` sets `Authorization` itself, from a token read once when `PorchStorage` was constructed. Both of client-go's credential wrappers return early when that header is already there:

```go
func (rt *bearerAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
	if len(req.Header.Get("Authorization")) != 0 {
		return rt.rt.RoundTrip(req)
	}
```

so neither of them has ever run. Two things follow. A projected service account token is replaced by the kubelet well before it expires, and the operator keeps sending the one it read at startup until somebody restarts it. And under a kubeconfig the header is `Bearer ` with nothing after it, which is still a header, so an exec plugin is suppressed by an empty credential.

Against an httptest server that echoes what it receives:

```console
header set by hand              server saw "Bearer startup-snapshot"
left to client-go               server saw "Bearer current-token"
empty Bearer, kubeconfig case   server saw "Bearer"

t=0    before rotation          server saw "Bearer token-A"
t=0    just after rotation      server saw "Bearer token-A"     (1 minute cache)
t=55s                           server saw "Bearer token-B"
t=55s, header set by hand       server saw "Bearer token-A"
```

The last line is the bug. The file had said `token-B` for the better part of a minute and the request still carried `token-A`.

## What changes

The header is not written here any more, and the token goes on the `rest.Config` instead. `resolveCredentials` hands over the path wherever there is one rather than reading it, because that is what makes rotation work: `BearerTokenFile` is re-read as the process runs, `BearerToken` is not. An explicit `PorchStorageConfig.Token`, and a `TOKEN` that holds a token rather than a path, are still passed through as values since there is no file to follow.

`PorchStorage.token` goes with it. Nothing else read it.

## What moving the header costs

Reviewing this turned up something the issue did not mention. `net/http` drops an `Authorization` header the caller set when a redirect crosses hosts. It cannot drop one a RoundTripper adds on the next hop, because the transport runs after the client has decided which headers to carry over:

```console
$ go test -run TestAdvRedirect -v      # api on 127.0.0.1, redirect target on localhost
header set by the caller   -> the other host saw ""
header added by transport  -> the other host saw "Bearer secret-token"
```

So this change, on its own, would have sent the token wherever the API server pointed. Porch is an aggregated API server, which is exactly the position [CVE-2022-3172](https://github.com/kubernetes/kubernetes/issues/112513) describes:

> The fix blocks all 3XX responses from aggregated API servers by default.

Kubernetes decided a client should not follow those, and this client does not either. `newHTTPClient` sets `CheckRedirect` to refuse, and refuses outright if `rest.HTTPClientFor` handed back the shared `http.DefaultClient` rather than setting `CheckRedirect` on something the rest of the process uses. That only happens for a config with no TLS, no credentials and no timeout, which this operator never builds, but the alternative is a global side effect.

Two smaller things came out of the same pass. `TOKEN` naming an absolute path that is not there is refused rather than sent, because an unmounted volume or a typo used to reach the API server as the credential:

```
TOKEN=/var/run/secrets/kubernetes.io/serviceaccount/token
  -> Authorization: Bearer /var/run/secrets/kubernetes.io/serviceaccount/token
```

which comes back as an opaque 401 and writes the filesystem layout into whatever logs that request. Only a leading separator is tested and not any separator: a token in standard base64 can carry one, and that used to work.

An empty or blank token file is a startup failure naming the path now, where before it produced `Bearer ` with nothing after it. `TestMain` clears `TOKEN` too, since the package reads it.

`newHTTPClient` also refuses the shared `http.DefaultClient`, and that is not a theoretical guard: `rest.HTTPClientFor(&rest.Config{Host: ...})` really does hand it back, so setting `CheckRedirect` there would have reached every other user of the process. There is a test for it.

## Proof manifests

The exec half is the one the issue asserted without showing, so here it is both ways. Same kubeconfig, same plugin, same server:

```console
$ go test ./internal/nbi/storage/ -run TestPorchStorageAuth_ExecPluginIsRun -v
    exec plugin -> server saw "Bearer token-from-exec-plugin"

$ # with req.Header.Set("Authorization", "Bearer ") put back, as on main
    exec plugin -> server saw "Bearer"
```

```console
$ make unit
=== RUN   TestPorchStorageAuth_ResolvesCredentials
=== RUN   TestPorchStorageAuth_ResolvesCredentials/an_explicit_token_is_used_as_it_is
=== RUN   TestPorchStorageAuth_ResolvesCredentials/TOKEN_naming_a_file_is_followed_rather_than_read
=== RUN   TestPorchStorageAuth_ResolvesCredentials/TOKEN_holding_a_token_is_used_as_it_is
=== RUN   TestPorchStorageAuth_ResolvesCredentials/the_mounted_token_is_followed_rather_than_read
=== RUN   TestPorchStorageAuth_ResolvesCredentials/the_kubeconfig_is_the_last_resort
=== RUN   TestPorchStorageAuth_TransportSigns
=== RUN   TestPorchStorageAuth_ExecPluginIsRun
ok      .../internal/nbi/storage
247 tests run, 0 failures        # 231 before

$ make lint
0 issues.

$ make gosec
  Issues : 0
```

Every part of the change was run against the mutation it is meant to catch:

```console
header set by hand again          5 tests fail
CheckRedirect removed             1 test fails
DefaultClient guard removed       1 test fails
TOKEN file read, not followed     5 tests fail
mounted token read, not followed  2 tests fail
absolute-path check removed       2 tests fail
```

The three new tests share the `TestPorchStorageAuth` prefix and that prefix is added to the `-run` allowlist in the unit target. Without it they would have been invisible to `presubmit-nephio-go-test`, which is the trap #1168 added its own entry to avoid and which I walked into anyway: `make unit` ran none of the three until the rename.

The suite gives the same answer with a hostile environment and inside a pod:

```console
$ env TOKEN=/etc/hostname                        go test ./internal/nbi/storage/   ok
$ env TOKEN=some-literal-token                   go test ./internal/nbi/storage/   ok
$ env KUBECONFIG=/etc/hostname                   go test ./internal/nbi/storage/   ok
$ env KUBERNETES_SERVICE_HOST=10.96.0.1 \
      KUBERNETES_SERVICE_PORT=443 -shuffle=on    go test ./internal/nbi/storage/   ok
```

and in a container without the host's `$HOME` or shell, since the exec test writes and runs a shell script:

```console
$ podman run --rm -v $PWD:/w -w /w/operators/focom-operator golang:1.25-alpine \
    go test ./internal/nbi/storage/ -run TestPorchStorageAuth -v
--- PASS: TestPorchStorageAuth_TransportSigns
--- PASS: TestPorchStorageAuth_ExecPluginIsRun
--- PASS: TestPorchStorageAuth_ResolvesCredentials
```

A few other shapes were checked and needed nothing. Fifty concurrent requests through one client, under `-race`, all carry the same correct header. A symlinked token works, which matters because that is what a projected volume is: the mounted file is a link into `..data` and the kubelet rotates by moving where it points; there is a test for it. An unreadable token file and a directory in place of one both fail at construction naming the path.

## What is not asserted, and why

Rotation itself. client-go caches a token file for a minute and that period is not reachable from `rest.Config`, so a test of it costs a minute of CI to watch one boolean. What is asserted is the half that decides it: `resolveCredentials` hands over the path. The 55 second measurement above was run by hand.

`TestResolveToken_Priority` is replaced rather than adapted. It asserted on the field that has gone, and its in-cluster case set `TOKEN` to a temporary file to stand in for the mounted path, so it never reached the branch it was named after. `inClusterTokenFile` is a variable now, as the CA path already was, so that branch can be reached.

`internal/controller` fails under `go test -count=3` — on this branch, on its base, and on `main`. It is state left between runs in a package this change does not touch.

## Left out on purpose

The issue also suggested reusing the manager's `rest.Config` and deleting the second discovery path in `PorchStorage`. That is not done here, and I described it as duplication rather than a fault, which was wrong. There is a defect in it:

```console
current-context names production-user, the operator resolves: "DEVELOPMENT-TOKEN"
```

`readTokenFromKubeconfig` parses the kubeconfig by hand and takes `users[0]`, so a file with more than one user authenticates as whichever is listed first and `kubectl config use-context` does nothing. That is #1186. It is reached only as the last of three fallbacks, so it does not affect a pod, and it changes which credential is selected, which is why it is not folded into a PR this size. `clientcmd` is already imported here and resolves the context correctly, so the fix is small.

Collapsing the discovery path itself would have to carry `KubernetesURL`, `CAFile`, `InsecureSkipTLSVerify`, `UseKubeconfig` and `Kubeconfig` onto a config the manager owns. It does not need controller-runtime in this package, since the caller can pass a copied `rest.Config`, but the override rules deserve their own change.

## Notes for maintainers

This is stacked on #1168. It touches the same file, and the CA scoping that PR adds is what `buildRESTConfig` looks like here. It will not apply to `main` on its own.

`docs/ARCHITECTURE.md` claimed automatic token rotation in the in-cluster section, which was the intent rather than the behaviour; it now says the client is given the path. `internal/nbi/testconfig.go` said exec plugins were not yet honoured, which was true and is not any more. I found nothing in nephio-project/docs describing either, so no companion PR looks needed.

Release triage is yours. The change is confined to the FOCOM operator's Porch client.

